### PR TITLE
Fixes for the structure missalignments

### DIFF
--- a/Cpp2IL/AssemblyBuilder.cs
+++ b/Cpp2IL/AssemblyBuilder.cs
@@ -161,6 +161,9 @@ namespace Cpp2IL
             while (current.BaseType != null)
             {
                 var targetName = current.BaseType.FullName;
+                if (targetName.Contains("<"))   // types with generic parameters (Type'1<T>) are stored as Type'1, so I just removed the part that causes trouble and called it a day
+                    targetName = targetName.Substring(0,targetName.IndexOf("<"));
+                
                 current = SharedState.AllTypeDefinitions.Find(t => t.FullName == targetName);
 
                 if (current == null)
@@ -169,7 +172,7 @@ namespace Cpp2IL
                     break;
                 }
 
-                baseFields.AddRange(current.Fields.Where(f => !f.IsStatic));
+                baseFields.InsertRange(0,current.Fields.Where(f => !f.IsStatic));   // each loop we go one inheritage level deeper, so these "new" fields should be inserted before the previous ones 
             }
 
             //Handle base fields


### PR DESCRIPTION
Just a few quick fixes for your awesome decompiler. I've noticed the field offsets on the metadata files didn't match with il2cpp dumper's output and looking further into it with Ghidra and the other files revealed a few issues.
Looks like types with generic parameters are not located so I made a hack around it since I'm not familiar with the code (you should definitely change that) and the structs are not pieced together as they should, as I explained in the comment.
Very cool project, keep at it!