### PR TITLE
API methods for injected attribute removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ LibCpp2ILTests/obj/
 Cpp2IL.Core/obj/
 
 Cpp2IL.Core/bin/
+
+.vs

--- a/Cpp2IL.Core/AssemblyUnpopulator.cs
+++ b/Cpp2IL.Core/AssemblyUnpopulator.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Cpp2IL.Core
 {
-	internal static class AssemblyUnpopulator
+    internal static class AssemblyUnpopulator
     {
         internal const string InjectedNamespaceName = "Cpp2IlInjected";
 

--- a/Cpp2IL.Core/AssemblyUnpopulator.cs
+++ b/Cpp2IL.Core/AssemblyUnpopulator.cs
@@ -1,0 +1,66 @@
+﻿using Mono.Cecil;
+using System;
+
+namespace Cpp2IL.Core
+{
+	internal static class AssemblyUnpopulator
+    {
+        internal const string InjectedNamespaceName = "Cpp2IlInjected";
+
+        public static void UnpopulateStubTypesInAssembly(AssemblyDefinition imageDef)
+        {
+            TypeDefinition addressAttribute = imageDef.MainModule.GetType(InjectedNamespaceName + ".AddressAttribute");
+            TypeDefinition fieldOffsetAttribute = imageDef.MainModule.GetType(InjectedNamespaceName + ".FieldOffsetAttribute");
+            TypeDefinition attributeAttribute = imageDef.MainModule.GetType(InjectedNamespaceName + ".AttributeAttribute");
+            TypeDefinition metadataOffsetAttribute = imageDef.MainModule.GetType(InjectedNamespaceName + ".MetadataOffsetAttribute");
+            TypeDefinition tokenAttribute = imageDef.MainModule.GetType(InjectedNamespaceName + ".TokenAttribute");
+            var attributeTypes = new TypeDefinition[] { addressAttribute, fieldOffsetAttribute, attributeAttribute, metadataOffsetAttribute, tokenAttribute };
+
+            foreach (var type in imageDef.MainModule.Types!)
+                RemoveInjectedAttributesFromType(type, attributeTypes);
+
+            imageDef.MainModule.Types.Remove(addressAttribute);
+            imageDef.MainModule.Types.Remove(fieldOffsetAttribute);
+            imageDef.MainModule.Types.Remove(attributeAttribute);
+            imageDef.MainModule.Types.Remove(metadataOffsetAttribute);
+            imageDef.MainModule.Types.Remove(tokenAttribute);
+        }
+
+        private static void RemoveInjectedAttributesFromType(TypeDefinition type, TypeDefinition[] attributeTypes)
+        {
+            try
+            {
+                foreach (var field in type.Fields)
+                    RemoveInjectedAttribute(field.CustomAttributes, attributeTypes);
+                foreach (var @event in type.Events)
+                    RemoveInjectedAttribute(@event.CustomAttributes, attributeTypes);
+                foreach (var property in type.Properties)
+                    RemoveInjectedAttribute(property.CustomAttributes, attributeTypes);
+                foreach (var method in type.Methods)
+                    RemoveInjectedAttribute(method.CustomAttributes, attributeTypes);
+                RemoveInjectedAttribute(type.CustomAttributes, attributeTypes);
+
+                foreach (var nestedType in type.NestedTypes)
+                    RemoveInjectedAttributesFromType(nestedType, attributeTypes);
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Failed to process type {type.FullName} (module {type.Module.Name}, declaring type {type.DeclaringType?.FullName})", e);
+            }
+        }
+
+        private static void RemoveInjectedAttribute(Mono.Collections.Generic.Collection<CustomAttribute> customAttributes, TypeDefinition[] attributeTypes)
+        {
+            foreach (var attributeType in attributeTypes)
+                RemoveInjectedAttribute(customAttributes, attributeType);
+        }
+
+        private static void RemoveInjectedAttribute(Mono.Collections.Generic.Collection<CustomAttribute> customAttributes, TypeDefinition attributeType)
+        {
+            foreach (var attr in customAttributes.ToArray())
+            {
+                if (attr.AttributeType == attributeType) customAttributes.Remove(attr);
+            }
+        }
+    }
+}

--- a/Cpp2IL.Core/Cpp2IlApi.cs
+++ b/Cpp2IL.Core/Cpp2IlApi.cs
@@ -186,6 +186,21 @@ namespace Cpp2IL.Core
             AttributeRestorer.ApplyCustomAttributesToAllTypesInAssembly(assembly, keyFunctionAddresses);
         }
 
+        public static void RemoveInjectedAttributesForAllAssemblies()
+        {
+            CheckLibInitialized();
+
+            foreach (var assembly in SharedState.AssemblyList)
+                AssemblyUnpopulator.UnpopulateStubTypesInAssembly(assembly);
+        }
+
+        public static void RemoveInjectedAttributesForAssembly(AssemblyDefinition assembly)
+        {
+            CheckLibInitialized();
+
+            AssemblyUnpopulator.UnpopulateStubTypesInAssembly(assembly);
+        }
+
         public static void GenerateMetadataForAllAssemblies(string rootFolder)
         {
             CheckLibInitialized();
@@ -219,7 +234,13 @@ namespace Cpp2IL.Core
         public static void SaveAssemblies(string toWhere, List<AssemblyDefinition> assemblies)
         {
             Logger.InfoNewline($"Saving {assemblies.Count} assembl{(assemblies.Count != 1 ? "ies" : "y")} to " + toWhere + "...");
-            
+
+            if (!Directory.Exists(toWhere))
+            {
+                Logger.VerboseNewline($"\tSave directory does not exist. Creating...");
+                Directory.CreateDirectory(toWhere);
+            }
+
             foreach (var assembly in assemblies)
             {
                 var dllPath = Path.Combine(toWhere, assembly.MainModule.Name);


### PR DESCRIPTION
This pull request adds two new API methods for removing injected attributes from assembly definitions. These methods are necessary because the injected attributes are needed for running attribute restoration.

This also fixes a small bug where a non-existent output folder would cause an error and prevent saving.