### PR TITLE
fix array initializer pointer increment

### DIFF
--- a/Cpp2IL.Core/Utils.cs
+++ b/Cpp2IL.Core/Utils.cs
@@ -744,6 +744,7 @@ namespace Cpp2IL.Core
                     8 => metadata.ReadClassAtRawAddr<long>(pointer)!,
                     _ => results[i]
                 });
+                pointer += (int)elementSize;
             }
 
             return results;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13888932/127151310-398d0157-271f-4582-a91d-35b73daa417f.png)
before: Initializes array containing values: [1, 1, 1, 1]
after: Initializes array containing values: [1, 2, 3, 4]