### PR TITLE
treat cecil TypeReference as RuntimeTypeHandle

### DIFF
--- a/Cpp2IL.Core/Analysis/MethodUtils.cs
+++ b/Cpp2IL.Core/Analysis/MethodUtils.cs
@@ -179,6 +179,8 @@ namespace Cpp2IL.Core.Analysis
                             break; //We allow this, because an IntPtr is usually a type or, more commonly, method pointer.
                         if (typeof(FieldReference).IsAssignableFrom(cons.Type) && parameterType.Name == "RuntimeFieldHandle")
                             break; //These are the same struct - we represent it as a FieldReference but it's actually a runtime field handle.
+                        if (typeof(TypeReference).IsAssignableFrom(cons.Type) && parameterType.Name == "RuntimeTypeHandle")
+                            break; //These are the same struct - we represent it as a TypeReference but it's actually a runtime type handle.
                         return false;
                     case LocalDefinition local:
                         if (parameterType.IsArray && local.Type?.IsArray != true)

--- a/Cpp2IL.Core/Analysis/ResultModels/ConstantDefinition.cs
+++ b/Cpp2IL.Core/Analysis/ResultModels/ConstantDefinition.cs
@@ -90,7 +90,9 @@ namespace Cpp2IL.Core.Analysis.ResultModels
 
             if (Type == typeof(MethodReference) && Value is MethodReference reference)
                 return new[] {ilProcessor.Create(OpCodes.Ldftn, reference)};
-
+            
+            if (Type == typeof(TypeReference) && Value is TypeReference typeReference)
+                return new[] {ilProcessor.Create(OpCodes.Ldtoken, typeReference)};
 
             if (Type == typeof(FieldDefinition) && Value is FieldDefinition fieldDefinition)
                 return new[] {ilProcessor.Create(OpCodes.Ldtoken, fieldDefinition)};


### PR DESCRIPTION
same as FieldReference and RuntimeFieldHandle

code and il:
![image](https://user-images.githubusercontent.com/13888932/127190360-32133119-7b20-4e68-839f-28a2d06d0d11.png)
![image](https://user-images.githubusercontent.com/13888932/127190507-913821bc-963c-4fd4-8f6e-fabb3f77085a.png)

output before:
![image](https://user-images.githubusercontent.com/13888932/127190537-086dbe29-190b-437d-822f-666f578a901c.png)

output after:
![image](https://user-images.githubusercontent.com/13888932/127190573-dfe25337-785a-441e-a077-4646c4b8ef1e.png)
