### PR TITLE
Move console logging logic to main Cpp2IL project

### DIFF
--- a/Cpp2IL.Core/Cpp2IL.Core.csproj
+++ b/Cpp2IL.Core/Cpp2IL.Core.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <PackageId>Samboy063.Cpp2IL.Core</PackageId>
         <Company>Samboy063</Company>

--- a/Cpp2IL.Core/Cpp2IL.Core.csproj
+++ b/Cpp2IL.Core/Cpp2IL.Core.csproj
@@ -27,7 +27,6 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-        <PackageReference Include="Pastel" Version="2.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Cpp2IL.Core/Cpp2IlApi.cs
+++ b/Cpp2IL.Core/Cpp2IlApi.cs
@@ -65,7 +65,7 @@ namespace Cpp2IL.Core
             return version;
         }
 
-        private static void ConfigureLib(bool verbose, bool allowUserToInputAddresses)
+        private static void ConfigureLib(bool allowUserToInputAddresses)
         {
             //Set this flag from the options
             LibCpp2IlMain.Settings.AllowManualMetadataAndCodeRegInput = allowUserToInputAddresses;
@@ -74,14 +74,13 @@ namespace Cpp2IL.Core
             LibCpp2IlMain.Settings.DisableMethodPointerMapping = false;
 
             LibLogger.Writer = new LibLogWriter();
-            LibLogger.ShowVerbose = Logger.ShowVerbose = verbose;
         }
 
-        public static void InitializeLibCpp2Il(string assemblyPath, string metadataPath, int[] unityVersion, bool verbose = false, bool allowUserToInputAddresses = false)
+        public static void InitializeLibCpp2Il(string assemblyPath, string metadataPath, int[] unityVersion, bool allowUserToInputAddresses = false)
         {
             if (IsLibInitialized())
                 ResetInternalState();
-            ConfigureLib(verbose, allowUserToInputAddresses);
+            ConfigureLib(allowUserToInputAddresses);
 
             try
             {
@@ -94,11 +93,11 @@ namespace Cpp2IL.Core
             }
         }
 
-        public static void InitializeLibCpp2Il(byte[] assemblyData, byte[] metadataData, int[] unityVersion, bool verbose = false, bool allowUserToInputAddresses = false)
+        public static void InitializeLibCpp2Il(byte[] assemblyData, byte[] metadataData, int[] unityVersion, bool allowUserToInputAddresses = false)
         {
             if (IsLibInitialized())
                 ResetInternalState();
-            ConfigureLib(verbose, allowUserToInputAddresses);
+            ConfigureLib(allowUserToInputAddresses);
 
             try
             {

--- a/Cpp2IL.Core/Cpp2IlApi.cs
+++ b/Cpp2IL.Core/Cpp2IlApi.cs
@@ -76,6 +76,10 @@ namespace Cpp2IL.Core
             LibLogger.Writer = new LibLogWriter();
         }
 
+        [Obsolete("Use InitializeLibCpp2Il(string, string, int[], bool) instead as verbose is deprecated", true)]
+        public static void InitializeLibCpp2Il(string assemblyPath, string metadataPath, int[] unityVersion, bool verbose = false, bool allowUserToInputAddresses = false)
+	        => InitializeLibCpp2Il(assemblyPath, metadataPath, unityVersion, allowUserToInputAddresses);
+
         public static void InitializeLibCpp2Il(string assemblyPath, string metadataPath, int[] unityVersion, bool allowUserToInputAddresses = false)
         {
             if (IsLibInitialized())
@@ -92,6 +96,10 @@ namespace Cpp2IL.Core
                 throw new LibCpp2ILInitializationException("Fatal Exception initializing LibCpp2IL!", e);
             }
         }
+
+        [Obsolete("Use InitializeLibCpp2Il(byte[], string, int[], bool) instead as verbose is deprecated", true)]
+        public static void InitializeLibCpp2Il(byte[] assemblyData, byte[] metadataData, int[] unityVersion, bool verbose = false, bool allowUserToInputAddresses = false)
+	        => InitializeLibCpp2Il(assemblyData, metadataData, unityVersion, allowUserToInputAddresses);
 
         public static void InitializeLibCpp2Il(byte[] assemblyData, byte[] metadataData, int[] unityVersion, bool allowUserToInputAddresses = false)
         {

--- a/Cpp2IL.Core/Cpp2IlApi.cs
+++ b/Cpp2IL.Core/Cpp2IlApi.cs
@@ -78,7 +78,7 @@ namespace Cpp2IL.Core
 
         [Obsolete("Use InitializeLibCpp2Il(string, string, int[], bool) instead as verbose is deprecated", true)]
         public static void InitializeLibCpp2Il(string assemblyPath, string metadataPath, int[] unityVersion, bool verbose = false, bool allowUserToInputAddresses = false)
-	        => InitializeLibCpp2Il(assemblyPath, metadataPath, unityVersion, allowUserToInputAddresses);
+            => InitializeLibCpp2Il(assemblyPath, metadataPath, unityVersion, allowUserToInputAddresses);
 
         public static void InitializeLibCpp2Il(string assemblyPath, string metadataPath, int[] unityVersion, bool allowUserToInputAddresses = false)
         {
@@ -99,7 +99,7 @@ namespace Cpp2IL.Core
 
         [Obsolete("Use InitializeLibCpp2Il(byte[], string, int[], bool) instead as verbose is deprecated", true)]
         public static void InitializeLibCpp2Il(byte[] assemblyData, byte[] metadataData, int[] unityVersion, bool verbose = false, bool allowUserToInputAddresses = false)
-	        => InitializeLibCpp2Il(assemblyData, metadataData, unityVersion, allowUserToInputAddresses);
+            => InitializeLibCpp2Il(assemblyData, metadataData, unityVersion, allowUserToInputAddresses);
 
         public static void InitializeLibCpp2Il(byte[] assemblyData, byte[] metadataData, int[] unityVersion, bool allowUserToInputAddresses = false)
         {

--- a/Cpp2IL.Core/Logger.cs
+++ b/Cpp2IL.Core/Logger.cs
@@ -4,10 +4,10 @@ namespace Cpp2IL.Core
 {
     public static class Logger
     {
-	    public delegate void LogEvent(string message, string source);
+        public delegate void LogEvent(string message, string source);
 
-	    public static event LogEvent VerboseLog = (_, _) => {};
-	    public static event LogEvent InfoLog = (_, _) => { };
+        public static event LogEvent VerboseLog = (_, _) => {};
+        public static event LogEvent InfoLog = (_, _) => { };
         public static event LogEvent WarningLog = (_, _) => { };
         public static event LogEvent ErrorLog = (_, _) => { };
 
@@ -29,7 +29,7 @@ namespace Cpp2IL.Core
 
         public static void Warn(string message, string source = "Program")
         {
-	        WarningLog(message, source);
+            WarningLog(message, source);
         }
         
         public static void ErrorNewline(string message, string source = "Program") => Error($"{message}{Environment.NewLine}", source);

--- a/Cpp2IL.Core/Logger.cs
+++ b/Cpp2IL.Core/Logger.cs
@@ -1,106 +1,42 @@
 ﻿using System;
-using System.Drawing;
-using System.IO;
-using Pastel;
 
 namespace Cpp2IL.Core
 {
     public static class Logger
     {
-        internal static readonly Color VERB = Color.Gray;
-        internal static readonly Color INFO = Color.LightBlue;
-        internal static readonly Color WARN = Color.Yellow;
-        internal static readonly Color ERROR = Color.DarkRed;
+	    public delegate void LogEvent(string message, string source);
 
-        public static Action<string, string>? VerboseOverride { get; set; }
-        public static Action<string, string>? InfoOverride { get; set; }
-        public static Action<string, string>? WarnOverride { get; set; }
-        public static Action<string, string>? ErrorOverride { get; set; }
-
-        internal static bool DisableColor { private get; set; }
-
-        internal static bool ShowVerbose { private get; set; }
-        
-        private static bool LastNoNewline;
+	    public static event LogEvent VerboseLog;
+	    public static event LogEvent InfoLog;
+	    public static event LogEvent WarningLog;
+	    public static event LogEvent ErrorLog;
 
         public static void VerboseNewline(string message, string source = "Program") => Verbose($"{message}{Environment.NewLine}", source);
 
         public static void Verbose(string message, string source = "Program")
         {
-            if (VerboseOverride != null) 
-                VerboseOverride.Invoke(message, source);
-            else if(ShowVerbose)
-                Write("Verb", source, message, VERB);
+            VerboseLog?.Invoke(message, source);
         }
         
         public static void InfoNewline(string message, string source = "Program") => Info($"{message}{Environment.NewLine}", source);
 
         public static void Info(string message, string source = "Program")
         {
-            if (InfoOverride != null) 
-                InfoOverride.Invoke(message, source);
-            else 
-                Write("Info", source, message, INFO);
+            InfoLog?.Invoke(message, source);
         }
         
         public static void WarnNewline(string message, string source = "Program") => Warn($"{message}{Environment.NewLine}", source);
 
         public static void Warn(string message, string source = "Program")
         {
-            if (WarnOverride != null) 
-                WarnOverride.Invoke(message, source);
-            else 
-                Write("Warn", source, message, WARN);
+	        WarningLog?.Invoke(message, source);
         }
         
         public static void ErrorNewline(string message, string source = "Program") => Error($"{message}{Environment.NewLine}", source);
 
         public static void Error(string message, string source = "Program")
         {
-            if (ErrorOverride != null) 
-                ErrorOverride.Invoke(message, source);
-            else 
-                Write("Fail", source, message, ERROR);
-        }
-
-        internal static void Write(string level, string source, string message, Color color)
-        {
-            WritePrelude(level, source, color);
-            
-            LastNoNewline = !message.EndsWith("\n");
-            
-            if (!DisableColor)
-                message = message.Pastel(color);
-            
-            Console.Write(message);
-        }
-
-        private static void WritePrelude(string level, string source, Color color)
-        {
-            var message = $"[{level}] [{source}] ";
-            if (!DisableColor)
-                message = message.Pastel(color);
-            
-            if(!LastNoNewline)
-                Console.Write(message);
-        }
-
-        public static void CheckColorSupport()
-        {
-            // if (Environment.OSVersion.Platform != PlatformID.Win32NT)
-            // {
-            //     DisableColor = true;
-            //     WarnNewline("Looks like you're running on a non-windows platform. Disabling ANSI color codes.");
-            // }
-            /*else*/ if (Directory.Exists(@"Z:\usr\"))
-            {
-                DisableColor = true;
-                WarnNewline("Looks like you're running in wine or proton. Disabling ANSI color codes.");
-            } else if (Environment.GetEnvironmentVariable("NO_COLOR") != null)
-            {
-                DisableColor = true; //Just manually set this, even though Pastel respects the environment variable
-                WarnNewline("NO_COLOR set, disabling ANSI color codes as you requested.");
-            }
+            ErrorLog?.Invoke(message, source);
         }
     }
 }

--- a/Cpp2IL.Core/Logger.cs
+++ b/Cpp2IL.Core/Logger.cs
@@ -6,37 +6,37 @@ namespace Cpp2IL.Core
     {
 	    public delegate void LogEvent(string message, string source);
 
-	    public static event LogEvent VerboseLog;
-	    public static event LogEvent InfoLog;
-	    public static event LogEvent WarningLog;
-	    public static event LogEvent ErrorLog;
+	    public static event LogEvent VerboseLog = (_, _) => {};
+	    public static event LogEvent InfoLog = (_, _) => { };
+        public static event LogEvent WarningLog = (_, _) => { };
+        public static event LogEvent ErrorLog = (_, _) => { };
 
         public static void VerboseNewline(string message, string source = "Program") => Verbose($"{message}{Environment.NewLine}", source);
 
         public static void Verbose(string message, string source = "Program")
         {
-            VerboseLog?.Invoke(message, source);
+            VerboseLog(message, source);
         }
         
         public static void InfoNewline(string message, string source = "Program") => Info($"{message}{Environment.NewLine}", source);
 
         public static void Info(string message, string source = "Program")
         {
-            InfoLog?.Invoke(message, source);
+            InfoLog(message, source);
         }
         
         public static void WarnNewline(string message, string source = "Program") => Warn($"{message}{Environment.NewLine}", source);
 
         public static void Warn(string message, string source = "Program")
         {
-	        WarningLog?.Invoke(message, source);
+	        WarningLog(message, source);
         }
         
         public static void ErrorNewline(string message, string source = "Program") => Error($"{message}{Environment.NewLine}", source);
 
         public static void Error(string message, string source = "Program")
         {
-            ErrorLog?.Invoke(message, source);
+            ErrorLog(message, source);
         }
     }
 }

--- a/Cpp2IL/ConsoleLogger.cs
+++ b/Cpp2IL/ConsoleLogger.cs
@@ -6,74 +6,74 @@ using Pastel;
 
 namespace Cpp2IL
 {
-	internal static class ConsoleLogger
-	{
-		internal static readonly Color VERB = Color.Gray;
-		internal static readonly Color INFO = Color.LightBlue;
-		internal static readonly Color WARN = Color.Yellow;
-		internal static readonly Color ERROR = Color.DarkRed;
+    internal static class ConsoleLogger
+    {
+        internal static readonly Color VERB = Color.Gray;
+        internal static readonly Color INFO = Color.LightBlue;
+        internal static readonly Color WARN = Color.Yellow;
+        internal static readonly Color ERROR = Color.DarkRed;
 
-		internal static bool DisableColor { private get; set; }
+        internal static bool DisableColor { private get; set; }
 
-		internal static bool ShowVerbose { private get; set; }
+        internal static bool ShowVerbose { private get; set; }
 
-		private static bool LastNoNewline;
+        private static bool LastNoNewline;
 
-		public static void Initialize()
-		{
-			Logger.InfoLog += (message, source) => Write("Info", source, message, INFO);
-			Logger.WarningLog += (message, source) => Write("Warn", source, message, WARN);
-			Logger.ErrorLog += (message, source) => Write("Fail", source, message, ERROR);
+        public static void Initialize()
+        {
+            Logger.InfoLog += (message, source) => Write("Info", source, message, INFO);
+            Logger.WarningLog += (message, source) => Write("Warn", source, message, WARN);
+            Logger.ErrorLog += (message, source) => Write("Fail", source, message, ERROR);
 
-			Logger.VerboseLog += (message, source) =>
-			{
-				if (ShowVerbose)
-					Write("Verb", source, message, VERB);
-			};
+            Logger.VerboseLog += (message, source) =>
+            {
+                if (ShowVerbose)
+                    Write("Verb", source, message, VERB);
+            };
 
-			CheckColorSupport();
-		}
+            CheckColorSupport();
+        }
 
-		internal static void Write(string level, string source, string message, Color color)
-		{
-			if (!LastNoNewline)
-				WritePrelude(level, source, color);
+        internal static void Write(string level, string source, string message, Color color)
+        {
+            if (!LastNoNewline)
+                WritePrelude(level, source, color);
 
-			LastNoNewline = !message.EndsWith("\n");
+            LastNoNewline = !message.EndsWith("\n");
 
-			if (!DisableColor)
-				message = message.Pastel(color);
+            if (!DisableColor)
+                message = message.Pastel(color);
 
-			Console.Write(message);
-		}
+            Console.Write(message);
+        }
 
-		private static void WritePrelude(string level, string source, Color color)
-		{
-			var message = $"[{level}] [{source}] ";
-			if (!DisableColor)
-				message = message.Pastel(color);
-			
-			Console.Write(message);
-		}
+        private static void WritePrelude(string level, string source, Color color)
+        {
+            var message = $"[{level}] [{source}] ";
+            if (!DisableColor)
+                message = message.Pastel(color);
+            
+            Console.Write(message);
+        }
 
-		public static void CheckColorSupport()
-		{
-			// if (Environment.OSVersion.Platform != PlatformID.Win32NT)
-			// {
-			//     DisableColor = true;
-			//     WarnNewline("Looks like you're running on a non-windows platform. Disabling ANSI color codes.");
-			// }
-			/*else*/
-			if (Directory.Exists(@"Z:\usr\"))
-			{
-				DisableColor = true;
-				Logger.WarnNewline("Looks like you're running in wine or proton. Disabling ANSI color codes.");
-			}
-			else if (Environment.GetEnvironmentVariable("NO_COLOR") != null)
-			{
-				DisableColor = true; //Just manually set this, even though Pastel respects the environment variable
-				Logger.WarnNewline("NO_COLOR set, disabling ANSI color codes as you requested.");
-			}
-		}
+        public static void CheckColorSupport()
+        {
+            // if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            // {
+            //     DisableColor = true;
+            //     WarnNewline("Looks like you're running on a non-windows platform. Disabling ANSI color codes.");
+            // }
+            /*else*/
+            if (Directory.Exists(@"Z:\usr\"))
+            {
+                DisableColor = true;
+                Logger.WarnNewline("Looks like you're running in wine or proton. Disabling ANSI color codes.");
+            }
+            else if (Environment.GetEnvironmentVariable("NO_COLOR") != null)
+            {
+                DisableColor = true; //Just manually set this, even though Pastel respects the environment variable
+                Logger.WarnNewline("NO_COLOR set, disabling ANSI color codes as you requested.");
+            }
+        }
     }
 }

--- a/Cpp2IL/ConsoleLogger.cs
+++ b/Cpp2IL/ConsoleLogger.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Drawing;
+using System.IO;
+using Cpp2IL.Core;
+using Pastel;
+
+namespace Cpp2IL
+{
+	internal static class ConsoleLogger
+	{
+		internal static readonly Color VERB = Color.Gray;
+		internal static readonly Color INFO = Color.LightBlue;
+		internal static readonly Color WARN = Color.Yellow;
+		internal static readonly Color ERROR = Color.DarkRed;
+
+		internal static bool DisableColor { private get; set; }
+
+		internal static bool ShowVerbose { private get; set; }
+
+		private static bool LastNoNewline;
+
+		public static void Initialize()
+		{
+			Logger.InfoLog += (message, source) => Write("Info", source, message, INFO);
+			Logger.WarningLog += (message, source) => Write("Warn", source, message, WARN);
+			Logger.ErrorLog += (message, source) => Write("Fail", source, message, ERROR);
+
+			Logger.VerboseLog += (message, source) =>
+			{
+				if (ShowVerbose)
+					Write("Verb", source, message, VERB);
+			};
+
+			CheckColorSupport();
+		}
+
+		internal static void Write(string level, string source, string message, Color color)
+		{
+			if (!LastNoNewline)
+				WritePrelude(level, source, color);
+
+			LastNoNewline = !message.EndsWith("\n");
+
+			if (!DisableColor)
+				message = message.Pastel(color);
+
+			Console.Write(message);
+		}
+
+		private static void WritePrelude(string level, string source, Color color)
+		{
+			var message = $"[{level}] [{source}] ";
+			if (!DisableColor)
+				message = message.Pastel(color);
+			
+			Console.Write(message);
+		}
+
+		public static void CheckColorSupport()
+		{
+			// if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+			// {
+			//     DisableColor = true;
+			//     WarnNewline("Looks like you're running on a non-windows platform. Disabling ANSI color codes.");
+			// }
+			/*else*/
+			if (Directory.Exists(@"Z:\usr\"))
+			{
+				DisableColor = true;
+				Logger.WarnNewline("Looks like you're running in wine or proton. Disabling ANSI color codes.");
+			}
+			else if (Environment.GetEnvironmentVariable("NO_COLOR") != null)
+			{
+				DisableColor = true; //Just manually set this, even though Pastel respects the environment variable
+				Logger.WarnNewline("NO_COLOR set, disabling ANSI color codes as you requested.");
+			}
+		}
+    }
+}

--- a/Cpp2IL/Cpp2IL.csproj
+++ b/Cpp2IL/Cpp2IL.csproj
@@ -42,6 +42,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Pastel" Version="2.1.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Cpp2IL/Program.cs
+++ b/Cpp2IL/Program.cs
@@ -106,7 +106,7 @@ namespace Cpp2IL
             Console.WriteLine("===Cpp2IL by Samboy063===");
             Console.WriteLine("A Tool to Reverse Unity's \"il2cpp\" Build Process.\n");
 
-            Logger.CheckColorSupport();
+            ConsoleLogger.Initialize();
             
             Logger.InfoNewline("Running on " + Environment.OSVersion.Platform);
 
@@ -144,7 +144,9 @@ namespace Cpp2IL
             if (!runtimeArgs.Valid)
                 throw new SoftException("Arguments have Valid = false");
 
-            Cpp2IlApi.InitializeLibCpp2Il(runtimeArgs.PathToAssembly, runtimeArgs.PathToMetadata, runtimeArgs.UnityVersion, runtimeArgs.EnableVerboseLogging, runtimeArgs.EnableRegistrationPrompts);
+            ConsoleLogger.ShowVerbose = runtimeArgs.EnableVerboseLogging;
+
+            Cpp2IlApi.InitializeLibCpp2Il(runtimeArgs.PathToAssembly, runtimeArgs.PathToMetadata, runtimeArgs.UnityVersion, runtimeArgs.EnableRegistrationPrompts);
 
             Cpp2IlApi.MakeDummyDLLs(runtimeArgs.SuppressAttributes);
 


### PR DESCRIPTION
Main goal here was to move the reference to the Pastel nuget package from Cpp2IL.Core to the main Cpp2IL CLI project, as other users of Cpp2IL.Core don't necessarily want to include this reference

I've also replaced the `Action<string, string>` override system with an event based system, such that it's easier for users to subscribe and unsubscribe to logging events