### PR TITLE
Fix IsImplicitNRE not catching all NREs

### DIFF
--- a/Cpp2IL.Core/Analysis/Actions/x86/BaseX86ConditionalJumpAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/BaseX86ConditionalJumpAction.cs
@@ -24,6 +24,14 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
                     return true;
                 }
             }
+            
+            if (body.Count > 1 && body[0].Mnemonic == Mnemonic.Xor && body[1].Mnemonic == Mnemonic.Call && CallExceptionThrowerFunction.IsExceptionThrower(body[1].NearBranchTarget))
+            {
+                if (CallExceptionThrowerFunction.GetExceptionThrown(body[1].NearBranchTarget)?.Name == "NullReferenceException")
+                {
+                    return true;
+                }
+            }
 
             return false;
         }


### PR DESCRIPTION
Sometimes the branch target for a NRE throw in a function will be a xor instruction just before the call, this pr just makes sure it catches it. 
![image](https://user-images.githubusercontent.com/91314780/136654034-7a00d722-a327-4b82-9e7f-d5545d69d83a.png)
