### PR TITLE
Support for System.Boolean Type in ImmediateToFieldAction

### DIFF
--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/ImmediateToFieldAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/ImmediateToFieldAction.cs
@@ -32,6 +32,8 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
                 ConstantValue = BitConverter.ToSingle(BitConverter.GetBytes(rawConstant), 0);
             else if(destTypeName == "System.Double")
                 ConstantValue = BitConverter.ToDouble(BitConverter.GetBytes(rawConstant), 0);
+            else if (destTypeName == "System.Boolean")
+                ConstantValue = BitConverter.ToBoolean(BitConverter.GetBytes(rawConstant), 0);
         }
 
         protected override string? GetValueSummary() => ConstantValue?.ToString();


### PR DESCRIPTION
Some decompilers output strange things for assinging a ulong to a field of type bool. For example `this.disableInputUntilRecenter = ((ulong)1 != 0UL);` , by converting the ConstantValue to a Boolean in ImmediateToFieldAction it'll output il that most (if not all) decompilers should recognise and output as `this.disableInputUntilRecenter = true;`