### PR TITLE
Add CondionalMoveAction and correct constant types used in comparison and return actions

### DIFF
--- a/Cpp2IL.Core/Analysis/Actions/ARM64/Arm64ReturnAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/ARM64/Arm64ReturnAction.cs
@@ -26,6 +26,8 @@ namespace Cpp2IL.Core.Analysis.Actions.ARM64
 
             if (returnValue is LocalDefinition l)
                 RegisterUsedLocal(l, context);
+            
+            TryCorrectConstant(context);
         }
     }
 }

--- a/Cpp2IL.Core/Analysis/Actions/Base/AbstractComparisonAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/Base/AbstractComparisonAction.cs
@@ -71,11 +71,19 @@ namespace Cpp2IL.Core.Analysis.Actions.Base
                     }
                     if (!string.IsNullOrEmpty(argumentOneType?.FullName) && !argumentOneType!.IsArray)
                     {
-                        var argumentOneSystemType = typeof(int).Module.GetType(argumentOneType.FullName);
-                        if(argumentOneSystemType != null && Utils.TryLookupTypeDefKnownNotGeneric("System.IConvertible")!.IsAssignableFrom(argumentOneType) && argumentOneType.Name != "String")
+                        if (argumentOneType.Resolve().IsEnum)
                         {
-                            constantDefinition.Value = Utils.ReinterpretBytes((IConvertible)constantDefinition.Value, argumentOneType);
-                            constantDefinition.Type = argumentOneSystemType;
+                            constantDefinition.Type = typeof(int);
+                            constantDefinition.Value = Utils.ReinterpretBytes((IConvertible) constantDefinition.Value, typeof(int));
+                        }
+                        else
+                        {
+                            var argumentOneSystemType = typeof(int).Module.GetType(argumentOneType.FullName);
+                            if (argumentOneSystemType != null && Utils.TryLookupTypeDefKnownNotGeneric("System.IConvertible")!.IsAssignableFrom(argumentOneType) && argumentOneType.Name != "String")
+                            {
+                                constantDefinition.Value = Utils.ReinterpretBytes((IConvertible) constantDefinition.Value, argumentOneType);
+                                constantDefinition.Type = argumentOneSystemType;
+                            }
                         }
                     }
                 }

--- a/Cpp2IL.Core/Analysis/Actions/Base/AbstractComparisonAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/Base/AbstractComparisonAction.cs
@@ -75,8 +75,9 @@ namespace Cpp2IL.Core.Analysis.Actions.Base
                         var argumentOneTypeDefinition = argumentOneType.Resolve();
                         if (argumentOneTypeDefinition.IsEnum)
                         {
-                            constantDefinition.Type = typeof(int).Module.GetType(argumentOneTypeDefinition.GetEnumUnderlyingType().FullName);
-                            constantDefinition.Value = Utils.ReinterpretBytes((IConvertible) constantDefinition.Value, typeof(int));
+                            var underLyingType = typeof(int).Module.GetType(argumentOneTypeDefinition.GetEnumUnderlyingType().FullName);
+                            constantDefinition.Type = underLyingType;
+                            constantDefinition.Value = Utils.ReinterpretBytes((IConvertible) constantDefinition.Value, underLyingType);
                         }
                         else
                         {

--- a/Cpp2IL.Core/Analysis/Actions/Base/AbstractComparisonAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/Base/AbstractComparisonAction.cs
@@ -4,6 +4,7 @@ using Cpp2IL.Core.Analysis.ResultModels;
 using LibCpp2IL;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
 
 namespace Cpp2IL.Core.Analysis.Actions.Base
 {
@@ -71,9 +72,10 @@ namespace Cpp2IL.Core.Analysis.Actions.Base
                     }
                     if (!string.IsNullOrEmpty(argumentOneType?.FullName) && !argumentOneType!.IsArray)
                     {
-                        if (argumentOneType.Resolve().IsEnum)
+                        var argumentOneTypeDefinition = argumentOneType.Resolve();
+                        if (argumentOneTypeDefinition.IsEnum)
                         {
-                            constantDefinition.Type = typeof(int);
+                            constantDefinition.Type = typeof(int).Module.GetType(argumentOneTypeDefinition.GetEnumUnderlyingType().FullName);
                             constantDefinition.Value = Utils.ReinterpretBytes((IConvertible) constantDefinition.Value, typeof(int));
                         }
                         else

--- a/Cpp2IL.Core/Analysis/Actions/Base/AbstractReturnAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/Base/AbstractReturnAction.cs
@@ -58,6 +58,11 @@ namespace Cpp2IL.Core.Analysis.Actions.Base
         {
             if (!_isVoid && returnValue is ConstantDefinition constantDefinition && typeof(IConvertible).IsAssignableFrom(constantDefinition.Type) && constantDefinition.Type != typeof(string))
             {
+                if (context.ReturnType.Resolve().IsEnum)
+                {
+                    constantDefinition.Type = typeof(int);
+                    constantDefinition.Value = Utils.ReinterpretBytes((IConvertible) constantDefinition.Value, typeof(int));
+                }
                 if (!string.IsNullOrEmpty(context.ReturnType?.FullName))
                 {
                     var returnValueType = typeof(int).Module.GetType(context.ReturnType!.FullName);

--- a/Cpp2IL.Core/Analysis/Actions/Base/AbstractReturnAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/Base/AbstractReturnAction.cs
@@ -63,7 +63,7 @@ namespace Cpp2IL.Core.Analysis.Actions.Base
                     constantDefinition.Type = typeof(int);
                     constantDefinition.Value = Utils.ReinterpretBytes((IConvertible) constantDefinition.Value, typeof(int));
                 }
-                if (!string.IsNullOrEmpty(context.ReturnType?.FullName))
+                else if (!string.IsNullOrEmpty(context.ReturnType?.FullName))
                 {
                     var returnValueType = typeof(int).Module.GetType(context.ReturnType!.FullName);
                     if (!string.IsNullOrEmpty(returnValueType?.FullName) && !returnValueType!.IsArray)

--- a/Cpp2IL.Core/Analysis/Actions/Base/AbstractReturnAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/Base/AbstractReturnAction.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Cpp2IL.Core.Analysis.ResultModels;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
 
 namespace Cpp2IL.Core.Analysis.Actions.Base
 {
@@ -58,9 +59,10 @@ namespace Cpp2IL.Core.Analysis.Actions.Base
         {
             if (!_isVoid && returnValue is ConstantDefinition constantDefinition && typeof(IConvertible).IsAssignableFrom(constantDefinition.Type) && constantDefinition.Type != typeof(string))
             {
-                if (context.ReturnType.Resolve().IsEnum)
+                var returnTypeDefinition = context.ReturnType.Resolve();
+                if (returnTypeDefinition.IsEnum)
                 {
-                    constantDefinition.Type = typeof(int);
+                    constantDefinition.Type = typeof(int).Module.GetType(returnTypeDefinition.GetEnumUnderlyingType().FullName);
                     constantDefinition.Value = Utils.ReinterpretBytes((IConvertible) constantDefinition.Value, typeof(int));
                 }
                 else if (!string.IsNullOrEmpty(context.ReturnType?.FullName))

--- a/Cpp2IL.Core/Analysis/Actions/Base/AbstractReturnAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/Base/AbstractReturnAction.cs
@@ -62,8 +62,9 @@ namespace Cpp2IL.Core.Analysis.Actions.Base
                 var returnTypeDefinition = context.ReturnType.Resolve();
                 if (returnTypeDefinition.IsEnum)
                 {
-                    constantDefinition.Type = typeof(int).Module.GetType(returnTypeDefinition.GetEnumUnderlyingType().FullName);
-                    constantDefinition.Value = Utils.ReinterpretBytes((IConvertible) constantDefinition.Value, typeof(int));
+                    var underLyingType = typeof(int).Module.GetType(returnTypeDefinition.GetEnumUnderlyingType().FullName);
+                    constantDefinition.Type = underLyingType;
+                    constantDefinition.Value = Utils.ReinterpretBytes((IConvertible) constantDefinition.Value, underLyingType);
                 }
                 else if (!string.IsNullOrEmpty(context.ReturnType?.FullName))
                 {

--- a/Cpp2IL.Core/Analysis/Actions/x86/GlobalStringRefToConstantAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/GlobalStringRefToConstantAction.cs
@@ -11,7 +11,7 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
     public class GlobalStringRefToConstantAction : BaseAction<Instruction>
     {
         public readonly string? ResolvedString;
-        public  ConstantDefinition? ConstantWritten;
+        public ConstantDefinition? ConstantWritten;
         public LocalDefinition LastKnownLocalInReg;
         private string? _destReg;
 

--- a/Cpp2IL.Core/Analysis/Actions/x86/GlobalStringRefToConstantAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/GlobalStringRefToConstantAction.cs
@@ -11,7 +11,8 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
     public class GlobalStringRefToConstantAction : BaseAction<Instruction>
     {
         public readonly string? ResolvedString;
-        public readonly ConstantDefinition? ConstantWritten;
+        public  ConstantDefinition? ConstantWritten;
+        public LocalDefinition LastKnownLocalInReg;
         private string? _destReg;
 
         public GlobalStringRefToConstantAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
@@ -35,8 +36,9 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
                 _destReg = instruction.Op0Kind == OpKind.Register ? Utils.GetRegisterNameNew(instruction.Op0Register) : null;
             }
 
+            LastKnownLocalInReg = context.GetLocalInReg(_destReg);
             ConstantWritten = context.MakeConstant(typeof(string), ResolvedString, null, _destReg);
-            
+
             if (instruction.Mnemonic == Mnemonic.Push)
             {
                 context.Stack.Push(ConstantWritten);

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/ConditionalGlobalStringRefToConstantAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/ConditionalGlobalStringRefToConstantAction.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using Cpp2IL.Core.Analysis.Actions.Base;
+using Cpp2IL.Core.Analysis.ResultModels;
+using Iced.Intel;
+using Mono.Cecil.Cil;
+using MonoMod.Utils;
+using Instruction = Iced.Intel.Instruction;
+
+namespace Cpp2IL.Core.Analysis.Actions.x86.Important
+{
+    public class ConditionalGlobalStringRefToConstantAction : ConditionalMoveAction
+    {
+        private GlobalStringRefToConstantAction AssociatedStringLoad;
+        private LocalDefinition LocalCreated;
+        private string? _destReg;
+        public ConditionalGlobalStringRefToConstantAction(MethodAnalysis<Instruction> context, Instruction instruction, BaseAction<Instruction> baseAction) : base(context, instruction, baseAction)
+        {
+                var expectedIndex = context.Actions.IndexOf(_associatedCompare) + 1;
+                if (expectedIndex < context.Actions.Count && context.Actions[expectedIndex] is GlobalStringRefToConstantAction globalStringRefToConstantAction)
+                {
+                    AssociatedStringLoad = globalStringRefToConstantAction;
+                }
+                else if (context.Actions[context.Actions.IndexOf(_associatedCompare) - 1] is GlobalStringRefToConstantAction globalStringRefToConstantAction2)
+                {
+                    AssociatedStringLoad = globalStringRefToConstantAction2;
+                }
+                else
+                {
+                    // TODO: Account for other scenarios where its overwriting an old string old thats not found?
+                }
+
+                context.Actions.Remove(AssociatedStringLoad);
+                
+                _destReg = instruction.Op0Kind == OpKind.Register ? Utils.GetRegisterNameNew(instruction.Op0Register) : null;
+
+                var whatWeWant = context.DeclaringType.Module.ImportReference(Utils.StringReference);
+
+                var localAtDest = AssociatedStringLoad.LastKnownLocalInReg;
+
+                if ("System.String".Equals(localAtDest?.Type?.FullName))
+                    LocalCreated = localAtDest;
+                else
+                    LocalCreated = context.MakeLocal(whatWeWant, null, _destReg, AssociatedStringLoad.ResolvedString);
+                
+                RegisterUsedLocal(LocalCreated, context);
+        }
+
+        public override Mono.Cecil.Cil.Instruction[] ToILInstructions(MethodAnalysis<Instruction> context, ILProcessor processor)
+        {
+            if (_associatedCompare?.ArgumentOne == null || (!OnlyNeedToLoadOneOperand() && _associatedCompare.ArgumentTwo == null))
+                throw new TaintedInstructionException("One of the arguments is null");
+
+            if (LocalCreated == null)
+                throw new TaintedInstructionException("Local created was null");
+
+            var ret = new List<Mono.Cecil.Cil.Instruction>();       
+            var target = processor.Create(OpCodes.Nop);
+            
+            
+            ret.Add(processor.Create(OpCodes.Ldstr, AssociatedStringLoad.ResolvedString));
+            ret.Add(processor.Create(OpCodes.Stloc, LocalCreated.Variable));
+            
+            ret.AddRange(_associatedCompare.ArgumentOne.GetILToLoad(context, processor));
+
+            if (!OnlyNeedToLoadOneOperand())
+                ret.AddRange(_associatedCompare.ArgumentTwo!.GetILToLoad(context, processor));
+            
+            ret.Add(processor.Create(GetJumpOpcode(), target));
+
+            ret.Add(processor.Create(OpCodes.Ldstr, ((_moveAction as GlobalStringRefToConstantAction)!).ResolvedString));
+            ret.Add(processor.Create(OpCodes.Stloc, LocalCreated.Variable));
+
+            ret.Add(target);
+
+            return ret.ToArray();
+        }
+
+        public override string? ToPsuedoCode()
+        {
+            return $"string {LocalCreated?.Name} = {GetArgumentOnePseudocodeValue()} {GetJumpOpCodePseudoCodeValue()} {GetArgumentTwoPseudocodeValue()} ? \"{(_moveAction as GlobalStringRefToConstantAction).ResolvedString}\" : \"{AssociatedStringLoad.ResolvedString}\"";
+        }
+
+        public override string ToTextSummary()
+        {
+            return $"[!] Sets local {LocalCreated?.Name} in {_destReg} to \"{(_moveAction as GlobalStringRefToConstantAction).ResolvedString}\" if {GetArgumentOnePseudocodeValue()} {GetJumpOpCodePseudoCodeValue()} {GetArgumentTwoPseudocodeValue()} else it sets the local to \"{AssociatedStringLoad.ResolvedString}\"";
+        }
+    }
+}

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/ConditionalGlobalStringRefToConstantAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/ConditionalGlobalStringRefToConstantAction.cs
@@ -27,7 +27,7 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
                 }
                 else
                 {
-                    // TODO: Account for other scenarios where its overwriting an old string old thats not found?
+                    // TODO: Account for other scenarios where its overwriting an old string thats not found?
                 }
 
                 context.Actions.Remove(AssociatedStringLoad);
@@ -68,7 +68,7 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
             
             ret.Add(processor.Create(GetJumpOpcode(), target));
 
-            ret.Add(processor.Create(OpCodes.Ldstr, ((_moveAction as GlobalStringRefToConstantAction)!).ResolvedString));
+            ret.Add(processor.Create(OpCodes.Ldstr, (_moveAction as GlobalStringRefToConstantAction)!.ResolvedString));
             ret.Add(processor.Create(OpCodes.Stloc, LocalCreated.Variable));
 
             ret.Add(target);
@@ -83,7 +83,7 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
 
         public override string ToTextSummary()
         {
-            return $"[!] Sets local {LocalCreated?.Name} in {_destReg} to \"{(_moveAction as GlobalStringRefToConstantAction).ResolvedString}\" if {GetArgumentOnePseudocodeValue()} {GetJumpOpCodePseudoCodeValue()} {GetArgumentTwoPseudocodeValue()} else it sets the local to \"{AssociatedStringLoad.ResolvedString}\"";
+            return $"[!] Sets local {LocalCreated?.Name} in {_destReg} to \"{(_moveAction as GlobalStringRefToConstantAction)!.ResolvedString}\" if {GetArgumentOnePseudocodeValue()} {GetJumpOpCodePseudoCodeValue()} {GetArgumentTwoPseudocodeValue()} else it sets the local to \"{AssociatedStringLoad.ResolvedString}\"";
         }
     }
 }

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/CondtionalMoveAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/CondtionalMoveAction.cs
@@ -67,13 +67,49 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
 
         public override string? ToPsuedoCode()
         {
-            return $"if (Todo:Need to add condition here) {_moveAction.ToPsuedoCode()}";
+            return $"if ({GetArgumentOnePseudocodeValue()} {GetJumpOpCodePseudoCodeValue()} {GetArgumentTwoPseudocodeValue()}) {_moveAction.ToPsuedoCode()}";
+        }
+        
+        private string GetArgumentOnePseudocodeValue()
+        {
+            return _associatedCompare?.ArgumentOne == null ? "" : _associatedCompare.ArgumentOne.GetPseudocodeRepresentation();
+        }
+
+        private string GetArgumentTwoPseudocodeValue()
+        {
+            return _associatedCompare?.ArgumentTwo == null ? "" : _associatedCompare.ArgumentTwo.GetPseudocodeRepresentation();
         }
 
         public override string ToTextSummary()
         {
-            return $"{_moveAction.ToTextSummary()} based on previous condition";
+            return $"{_moveAction.ToTextSummary()} based on previous comparison";
         }
+
+        private string GetJumpOpCodePseudoCodeValue()
+        {
+            switch (AssociatedInstruction.Mnemonic)
+            {
+                case Mnemonic.Cmove:
+                    return "==";
+                case Mnemonic.Cmovne:
+                    return "!=";
+                case Mnemonic.Cmova:
+                case Mnemonic.Cmovg:
+                    return ">";
+                case Mnemonic.Cmovae:
+                case Mnemonic.Cmovge:
+                    return ">=";
+                case Mnemonic.Cmovb:
+                case Mnemonic.Cmovl:
+                    return "<";
+                case Mnemonic.Cmovbe:
+                case Mnemonic.Cmovle:
+                    return "<=";
+                default:
+                    return "(Unknown conditional operation)";
+            }
+        }
+        
         private OpCode GetJumpOpcode()
         {
             switch (AssociatedInstruction.Mnemonic)

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/CondtionalMoveAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/CondtionalMoveAction.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cpp2IL.Core.Analysis.Actions.Base;
+using Cpp2IL.Core.Analysis.ResultModels;
+using Iced.Intel;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Instruction = Iced.Intel.Instruction;
+
+namespace Cpp2IL.Core.Analysis.Actions.x86.Important
+{
+    public class ConditionalMoveAction : BaseAction<Instruction>
+    {
+        protected readonly ComparisonAction? _associatedCompare;
+        protected readonly BaseAction<Instruction> _moveAction;
+        private bool nullMode = false;
+        private bool booleanMode = false;
+        public ConditionalMoveAction(MethodAnalysis<Instruction> context, Instruction instruction, BaseAction<Instruction> moveAction) : base(context, instruction)
+        {
+            _associatedCompare = (ComparisonAction?) context.Actions.LastOrDefault(a => a is ComparisonAction);
+            _moveAction = moveAction;
+            
+            if (_associatedCompare != null && (instruction.Mnemonic == Mnemonic.Cmove || instruction.Mnemonic == Mnemonic.Cmovne))
+            {
+                nullMode = _associatedCompare.ArgumentOne == _associatedCompare.ArgumentTwo;
+                booleanMode = nullMode && _associatedCompare.ArgumentOne is LocalDefinition local && local.Type?.FullName == "System.Boolean";
+            }
+        }
+
+        public bool IsTypeCheckCondtionalMove()
+        {
+            if (_associatedCompare?.ArgumentTwo is null)
+                return false;
+
+            if (_associatedCompare.ArgumentOne is ConstantDefinition {Value: Il2CppClassIdentifier} && _associatedCompare.ArgumentTwo is ConstantDefinition {Value: TypeDefinition or TypeReference} && AssociatedInstruction.Mnemonic == Mnemonic.Cmove)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public override bool IsImportant() => !IsTypeCheckCondtionalMove();
+
+        public override Mono.Cecil.Cil.Instruction[] ToILInstructions(MethodAnalysis<Instruction> context, ILProcessor processor)
+        {
+            if (_associatedCompare?.ArgumentOne == null || (!OnlyNeedToLoadOneOperand() && _associatedCompare.ArgumentTwo == null))
+                throw new TaintedInstructionException("One of the arguments is null");
+
+            var ret = new List<Mono.Cecil.Cil.Instruction>();       
+            var target = processor.Create(OpCodes.Nop);
+
+            ret.AddRange(_associatedCompare.ArgumentOne.GetILToLoad(context, processor));
+
+            if (!OnlyNeedToLoadOneOperand())
+                ret.AddRange(_associatedCompare.ArgumentTwo.GetILToLoad(context, processor));
+            
+            ret.Add(processor.Create(GetJumpOpcode(), target));
+
+            ret.AddRange(_moveAction.ToILInstructions(context, processor));
+
+            ret.Add(target);
+
+            return ret.ToArray();
+        }
+
+        public override string? ToPsuedoCode()
+        {
+            return $"if (Todo:Need to add condition here)" + $"{_moveAction.ToPsuedoCode()}";
+        }
+
+        public override string ToTextSummary()
+        {
+            return $"{_moveAction.ToTextSummary()} based on previous condition";
+        }
+        private OpCode GetJumpOpcode()
+        {
+            switch (AssociatedInstruction.Mnemonic)
+            {
+                case Mnemonic.Cmove:
+                    return OpCodes.Brfalse;
+                case Mnemonic.Cmovne:
+                    return OpCodes.Brtrue;
+                case Mnemonic.Cmovg:
+                    return OpCodes.Ble;
+                case Mnemonic.Cmovge:
+                    return OpCodes.Blt;
+                case Mnemonic.Cmovl:
+                    return OpCodes.Bge;
+                case Mnemonic.Cmovle:
+                    return OpCodes.Bgt;
+                case Mnemonic.Cmova:
+                    return OpCodes.Ble_Un;
+                case Mnemonic.Cmovae:
+                    return OpCodes.Blt_Un;
+                case Mnemonic.Cmovb:
+                    return OpCodes.Bge_Un;
+                case Mnemonic.Cmovbe:
+                    return OpCodes.Bgt_Un;
+                default:
+                    throw new NotImplementedException($"Il generation for {AssociatedInstruction.Mnemonic} isn't implemented");
+                // TODO: Other Conditional Move Instructions?
+                // Not sure if they actually show up anywhere
+                //case Mnemonic.Cmovs: 
+                //case Mnemonic.Cmovns:
+            }
+        }
+        private bool OnlyNeedToLoadOneOperand() => booleanMode || nullMode;
+    }
+}

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/CondtionalMoveAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/CondtionalMoveAction.cs
@@ -26,19 +26,7 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
                 nullMode = _associatedCompare.ArgumentOne == _associatedCompare.ArgumentTwo;
                 booleanMode = nullMode && _associatedCompare.ArgumentOne is LocalDefinition local && local.Type?.FullName == "System.Boolean";
             }
-
-            if (Counter.TryGetValue(AssociatedInstruction.Mnemonic, out int value))
-            {
-                Counter[AssociatedInstruction.Mnemonic] = ++value;
-            }
-            else
-            {
-                Counter.Add(AssociatedInstruction.Mnemonic, 1);
-            }
         }
-
-        public static Dictionary<Mnemonic, int> Counter = new Dictionary<Mnemonic, int>();
-
 
         public bool IsTypeCheckCondtionalMove()
         {

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/CondtionalMoveAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/CondtionalMoveAction.cs
@@ -67,7 +67,7 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
 
         public override string? ToPsuedoCode()
         {
-            return $"if (Todo:Need to add condition here)" + $"{_moveAction.ToPsuedoCode()}";
+            return $"if (Todo:Need to add condition here) {_moveAction.ToPsuedoCode()}";
         }
 
         public override string ToTextSummary()

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/ReturnFromFunctionAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/ReturnFromFunctionAction.cs
@@ -13,6 +13,8 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
 
             if (returnValue is LocalDefinition l)
                 RegisterUsedLocal(l, context);
+
+            TryCorrectConstant(context);
         }
     }
 }

--- a/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
+++ b/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
@@ -298,12 +298,10 @@ namespace Cpp2IL.Core.Analysis
 
             if (mnemonic == Mnemonic.Comiss)
                 mnemonic = Mnemonic.Cmp;
-
-            
             
             //Noting here, format of a memory operand is:
             //[memoryBase + memoryIndex * memoryIndexScale + memoryOffset]
-
+            
             switch (mnemonic)
             {
                 case Mnemonic.Mov when !CppAssembly.is32Bit && type0 == OpKind.Register && type1 == OpKind.Register && offset0 == 0 && offset1 == 0 && op1 != null && instruction.Op1Register.IsGPR32():

--- a/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
+++ b/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
@@ -293,8 +293,7 @@ namespace Cpp2IL.Core.Analysis
 
             var mnemonic = instruction.Mnemonic;
 
-            if (mnemonic == Mnemonic.Movzx || mnemonic == Mnemonic.Movss || mnemonic == Mnemonic.Movsxd || mnemonic == Mnemonic.Movaps || mnemonic == Mnemonic.Movups || mnemonic == Mnemonic.Movdqa ||
-                mnemonic == Mnemonic.Cmove || mnemonic == Mnemonic.Cmovne || mnemonic == Mnemonic.Cmovge || mnemonic == Mnemonic.Cmovs || mnemonic == Mnemonic.Cmovns || mnemonic == Mnemonic.Cmovg || mnemonic == Mnemonic.Cmovge || mnemonic == Mnemonic.Cmovl || mnemonic == Mnemonic.Cmovle || mnemonic == Mnemonic.Cmova || mnemonic == Mnemonic.Cmovae || mnemonic == Mnemonic.Cmovb || mnemonic == Mnemonic.Cmovbe)
+            if (mnemonic == Mnemonic.Movzx || mnemonic == Mnemonic.Movss || mnemonic == Mnemonic.Movsxd || mnemonic == Mnemonic.Movaps || mnemonic == Mnemonic.Movups || mnemonic == Mnemonic.Movdqa || instruction.IsConditionalMove())
                 mnemonic = Mnemonic.Mov;
 
             if (mnemonic == Mnemonic.Comiss)

--- a/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
+++ b/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
@@ -376,7 +376,9 @@ namespace Cpp2IL.Core.Analysis
                                 Analysis.Actions.Add(MaybeWrap(new GlobalFieldDefToConstantAction(Analysis, instruction)));
                                 break;
                             case MetadataUsageType.StringLiteral:
-                                Analysis.Actions.Add(MaybeWrap(new GlobalStringRefToConstantAction(Analysis, instruction)));
+                                // Handle this one separately because it's special 
+                                Analysis.Actions.Add(!instruction.IsConditionalMove() ? new GlobalStringRefToConstantAction(Analysis, instruction)
+                                    : new ConditionalGlobalStringRefToConstantAction(Analysis, instruction, new GlobalStringRefToConstantAction(Analysis, instruction)));
                                 break;
                         }
                     }

--- a/Cpp2IL.Core/Analysis/ResultModels/ConstantDefinition.cs
+++ b/Cpp2IL.Core/Analysis/ResultModels/ConstantDefinition.cs
@@ -123,6 +123,15 @@ namespace Cpp2IL.Core.Analysis.ResultModels
 
             throw new TaintedInstructionException($"ConstantDefinition: Don't know how to get IL to load a {Type}");
         }
+        
+        public bool IsSafeToCorrect()
+        {
+            if (Value is GenericInstanceMethod or MethodReference or GenericInstanceMethod or TypeReference or FieldDefinition)
+            {
+                return false;
+            }
+            return true;
+        }
 
         
     }

--- a/Cpp2IL.Core/Analysis/ResultModels/MethodAnalysis.cs
+++ b/Cpp2IL.Core/Analysis/ResultModels/MethodAnalysis.cs
@@ -68,6 +68,11 @@ namespace Cpp2IL.Core.Analysis.ResultModels
             typeof(LoadConstantUsingLeaAction)
         };
 
+        public MethodDefinition GetMethodDefinition()
+        {
+            return _method;
+        }
+        
         //For analysing cpp-only methods, like attribute generators
         internal MethodAnalysis(ulong methodStart, ulong initialMethodEnd, IList<TInstruction> allInstructions)
         {

--- a/Cpp2IL.Core/Cpp2IlApi.cs
+++ b/Cpp2IL.Core/Cpp2IlApi.cs
@@ -482,7 +482,7 @@ namespace Cpp2IL.Core
                     }
                     catch (Exception e)
                     {
-                        Logger.WarnNewline($"Failed to dump methods for type {type.Name}, method {methodDefinition.Name} {e}", "Analyze");
+                        Logger.WarnNewline($"Failed to dump method {methodDefinition.FullName} {e}", "Analyze");
                     }
                 }
 

--- a/Cpp2IL.Core/Extensions.cs
+++ b/Cpp2IL.Core/Extensions.cs
@@ -45,6 +45,27 @@ namespace Cpp2IL.Core
         public static Arm64Register? MemoryIndex(this Arm64Instruction instruction) => MemoryOperand(instruction)?.Memory.Index;
         public static int MemoryOffset(this Arm64Instruction instruction) => MemoryOperand(instruction)?.Memory.Displacement ?? 0;
 
+        public static bool IsConditionalMove(this Instruction instruction)
+        {
+            switch (instruction.Mnemonic)
+            {
+                case Mnemonic.Cmove:
+                case Mnemonic.Cmovne:
+                case Mnemonic.Cmovs:
+                case Mnemonic.Cmovns:
+                case Mnemonic.Cmovg:
+                case Mnemonic.Cmovge:
+                case Mnemonic.Cmovl:
+                case Mnemonic.Cmovle:
+                case Mnemonic.Cmova:
+                case Mnemonic.Cmovae:
+                case Mnemonic.Cmovb:
+                case Mnemonic.Cmovbe:
+                    return true;
+                default:
+                    return false;
+            }
+        }
         public static Stack<T> Clone<T>(this Stack<T> original)
         {
             var arr = new T[original.Count];

--- a/Cpp2IL.Core/Utils.cs
+++ b/Cpp2IL.Core/Utils.cs
@@ -903,7 +903,7 @@ namespace Cpp2IL.Core
             if (desired == typeof(byte))
                 return rawBytes[0];
             if (desired == typeof(char))
-                return (char)rawBytes[0];
+                return BitConverter.ToChar(rawBytes, 0);
             if (desired == typeof(sbyte))
                 return unchecked((sbyte)rawBytes[0]);
             if (desired == typeof(ushort))

--- a/Cpp2IL/Program.cs
+++ b/Cpp2IL/Program.cs
@@ -6,6 +6,7 @@ using System.IO.Compression;
 using System.Linq;
 using CommandLine;
 using Cpp2IL.Core;
+using Cpp2IL.Core.Analysis.Actions.x86.Important;
 using Cpp2IL.Core.Exceptions;
 using LibCpp2IL;
 using LibCpp2IL.PE;
@@ -290,6 +291,10 @@ namespace Cpp2IL
                 else
                 {
                     DoAnalysisForAssembly(runtimeArgs.AssemblyToRunAnalysisFor, runtimeArgs.AnalysisLevel, runtimeArgs.OutputRootDirectory, keyFunctionAddresses!, runtimeArgs.EnableIlToAsm, runtimeArgs.Parallel, runtimeArgs.IlToAsmContinueThroughErrors);
+                    foreach (var kvp in ConditionalMoveAction.Counter)
+                    {
+                        Console.WriteLine($"Got: {kvp.Key} {kvp.Value} times");
+                    }
                 }
             }
 

--- a/Cpp2IL/Program.cs
+++ b/Cpp2IL/Program.cs
@@ -6,10 +6,8 @@ using System.IO.Compression;
 using System.Linq;
 using CommandLine;
 using Cpp2IL.Core;
-using Cpp2IL.Core.Analysis.Actions.x86.Important;
 using Cpp2IL.Core.Exceptions;
 using LibCpp2IL;
-using LibCpp2IL.PE;
 using Mono.Cecil;
 
 namespace Cpp2IL

--- a/Cpp2IL/Program.cs
+++ b/Cpp2IL/Program.cs
@@ -291,10 +291,6 @@ namespace Cpp2IL
                 else
                 {
                     DoAnalysisForAssembly(runtimeArgs.AssemblyToRunAnalysisFor, runtimeArgs.AnalysisLevel, runtimeArgs.OutputRootDirectory, keyFunctionAddresses!, runtimeArgs.EnableIlToAsm, runtimeArgs.Parallel, runtimeArgs.IlToAsmContinueThroughErrors);
-                    foreach (var kvp in ConditionalMoveAction.Counter)
-                    {
-                        Console.WriteLine($"Got: {kvp.Key} {kvp.Value} times");
-                    }
                 }
             }
 


### PR DESCRIPTION
- Implements an action that wraps around other actions that are generated from x86 Mov Instructions
- Detects and skips type checks that aren't needed in il
- Handles double strings constant loads (one using a normal mov and another using a cmov).
- Some methods that previously succeeded may now fail because they were incorrect to begin with
- Attempts to correct the type for constants used in comparison and return actions. This'll allow for better il to be generated and clean up decompilations