### PR TITLE
Set reg content if using LastKnownLocalInReg

### DIFF
--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/ConditionalGlobalStringRefToConstantAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/ConditionalGlobalStringRefToConstantAction.cs
@@ -43,9 +43,14 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
             var localAtDest = AssociatedStringLoad.LastKnownLocalInReg;
 
             if ("System.String".Equals(localAtDest?.Type?.FullName))
+            {
                 LocalCreated = localAtDest;
+                context.SetRegContent(_destReg!, LocalCreated);
+            }
             else
+            {
                 LocalCreated = context.MakeLocal(whatWeWant, null, _destReg, AssociatedStringLoad.ResolvedString);
+            }
 
             RegisterUsedLocal(LocalCreated, context);
         }


### PR DESCRIPTION
Fixes some empty if statements create from the ConditionalGlobalStringRefToConstantAction