### PR TITLE
Improve support for determining the unity version

### DIFF
--- a/Cpp2IL.Core/Cpp2IlApi.cs
+++ b/Cpp2IL.Core/Cpp2IlApi.cs
@@ -27,22 +27,33 @@ namespace Cpp2IL.Core
 
         public static int[] DetermineUnityVersion(string unityPlayerPath, string gameDataPath)
         {
-            int[] version;
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT && !string.IsNullOrEmpty(unityPlayerPath))
             {
                 var unityVer = FileVersionInfo.GetVersionInfo(unityPlayerPath);
 
-                version = new[] {unityVer.FileMajorPart, unityVer.FileMinorPart, unityVer.FileBuildPart};
+                return new[] {unityVer.FileMajorPart, unityVer.FileMinorPart, unityVer.FileBuildPart};
             }
-            else
+
+            if(!string.IsNullOrEmpty(gameDataPath))
             {
                 //Globalgamemanagers
                 var globalgamemanagersPath = Path.Combine(gameDataPath, "globalgamemanagers");
-                var ggmBytes = File.ReadAllBytes(globalgamemanagersPath);
-                version = GetVersionFromGlobalGameManagers(ggmBytes);
+                if(File.Exists(globalgamemanagersPath))
+                {
+                    var ggmBytes = File.ReadAllBytes(globalgamemanagersPath);
+                    return GetVersionFromGlobalGameManagers(ggmBytes);
+                }
+                
+                //Data.unity3d
+                var dataPath = Path.Combine(gameDataPath, "data.unity3d");
+                if(File.Exists(dataPath))
+                {
+                    using var dataStream = File.OpenRead(dataPath);
+                    return GetVersionFromDataUnity3D(dataStream);
+                }
             }
 
-            return version;
+            return null;
         }
 
         public static int[] GetVersionFromGlobalGameManagers(byte[] ggmBytes)


### PR DESCRIPTION
This was particularly present on non-windows systems where the unity player dll could not be used and the game was LZ4 compressed.