### PR TITLE
Various improvements to different aspects of x86 analysis

### DIFF
--- a/Cpp2IL.Core/Analysis/Actions/Base/AbstractArrayAllocationAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/Base/AbstractArrayAllocationAction.cs
@@ -1,4 +1,6 @@
-﻿using Cpp2IL.Core.Analysis.ResultModels;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Cpp2IL.Core.Analysis.ResultModels;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
@@ -7,6 +9,8 @@ namespace Cpp2IL.Core.Analysis.Actions.Base
     public abstract class AbstractArrayAllocationAction<T> : BaseAction<T>
     {
         protected int SizeAllocated;
+        protected bool LocalArraySize;
+        protected LocalDefinition? LocalUsedForArraySize;
         protected TypeReference? TypeOfArray;
         protected LocalDefinition? LocalWritten;
 
@@ -22,26 +26,39 @@ namespace Cpp2IL.Core.Analysis.Actions.Base
             if (TypeOfArray is not ArrayType arrayType)
                 throw new TaintedInstructionException("Array type isn't an array");
 
-            return new []
+            if (!LocalArraySize)
             {
-                processor.Create(OpCodes.Ldc_I4, SizeAllocated),
-                processor.Create(OpCodes.Newarr, processor.ImportReference(arrayType.ElementType)),
-                processor.Create(OpCodes.Stloc, LocalWritten.Variable)
-            };
+                return new[]
+                {
+                    processor.Create(OpCodes.Ldc_I4, SizeAllocated),
+                    processor.Create(OpCodes.Newarr, processor.ImportReference(arrayType.ElementType)),
+                    processor.Create(OpCodes.Stloc, LocalWritten.Variable)
+                };
+            }
+            else
+            {
+                if(LocalUsedForArraySize == null)
+                    throw new TaintedInstructionException("Missing local used for array size");
+                List<Instruction> instructions = new List<Instruction>();
+                instructions.AddRange(LocalUsedForArraySize.GetILToLoad(context, processor));
+                instructions.Add(processor.Create(OpCodes.Newarr, processor.ImportReference(arrayType.ElementType)));
+                instructions.Add(processor.Create(OpCodes.Stloc, LocalWritten.Variable));
+                return instructions.ToArray();
+            }
         }
 
         public override string? ToPsuedoCode()
         {
             var aType = TypeOfArray as ArrayType;
-            return $"{TypeOfArray?.FullName} {LocalWritten?.Name} = new {aType?.ElementType}[{SizeAllocated}]";
+            return $"{TypeOfArray?.FullName} {LocalWritten?.Name} = new {aType?.ElementType}[{(LocalArraySize ? LocalUsedForArraySize?.Name : SizeAllocated)}]";
         }
 
         public override string ToTextSummary()
         {
             if (!(TypeOfArray is ArrayType))
-                return $"[!!] Allocates an array of a type which isn't an array (got {TypeOfArray}), of size {SizeAllocated}, and stores the result as {LocalWritten?.Name}. This is a problem - we couldn't resolve the array type";
+                return $"[!!] Allocates an array of a type which isn't an array (got {TypeOfArray}), of size {(LocalArraySize ? LocalUsedForArraySize?.Name : SizeAllocated)}, and stores the result as {LocalWritten?.Name}. This is a problem - we couldn't resolve the array type";
             
-            return $"[!] Allocates an array of type {TypeOfArray?.FullName} of size {SizeAllocated} and stores the result as {LocalWritten?.Name} in register rax\n";
+            return $"[!] Allocates an array of type {TypeOfArray?.FullName} of size {(LocalArraySize ? LocalUsedForArraySize?.Name : SizeAllocated)} and stores the result as {LocalWritten?.Name} in register rax\n";
         }
 
         public override bool IsImportant()

--- a/Cpp2IL.Core/Analysis/Actions/x86/BoxValueAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/BoxValueAction.cs
@@ -16,7 +16,7 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
         private IAnalysedOperand? primitiveObject;
         private LocalDefinition? _localMade;
         private bool _boxingFieldPointer = false;
-        private FieldPointer _boxedField;
+        private FieldPointer? _boxedField;
 
         public BoxValueAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
         {

--- a/Cpp2IL.Core/Analysis/Actions/x86/BoxValueAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/BoxValueAction.cs
@@ -79,11 +79,8 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
             if (!_boxingFieldPointer)
                 throw new NotImplementedException("This shouldn't have happened");
 
-
-            // Skipping this, do want to deal with it now or think about it
-            return new Mono.Cecil.Cil.Instruction[0];
             
-            if (_localMade == null || _boxedField.OnWhat == null || _boxedField.Field == null)
+            if (_localMade == null || _boxedField?.OnWhat == null || _boxedField?.Field == null)
                 throw new TaintedInstructionException();
             
             var ret = new List<Mono.Cecil.Cil.Instruction>();
@@ -110,7 +107,7 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
 
         public override string ToTextSummary()
         {
-            return $"Boxes a cpp primitive value {primitiveObject} to managed type {destinationType?.FullName} and stores the result in new local {_localMade?.Name} in register rax.";
+            return $"Boxes a cpp primitive {(_boxingFieldPointer?"field":"value")} {primitiveObject} to managed type {destinationType?.FullName} and stores the result in new local {_localMade?.Name} in register rax.";
         }
     }
 }

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/AllocateArrayAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/AllocateArrayAction.cs
@@ -42,6 +42,12 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
             {
                 SizeAllocated = (int) sizeCSmall;
             }
+            else if (sizeOperand is LocalDefinition localDefinition)
+            {
+                LocalArraySize = true;
+                LocalUsedForArraySize = localDefinition;
+                RegisterUsedLocal(localDefinition, context);
+            }
 
             if (TypeOfArray is not ArrayType arrayType) return;
 

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/CallManagedFunctionAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/CallManagedFunctionAction.cs
@@ -26,12 +26,6 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
 
             if (LibCpp2IlMain.Binary!.ConcreteGenericImplementationsByAddress.TryGetValue(_jumpTarget, out var concMethods))
             {
-
-                // if (context.ToString().Contains("GetAnimCurveData"))
-                // {
-                //     Console.WriteLine("");
-                // }
-                
                 var genericMethodConstants = context.Constants.Where(c => c.Value is MethodReference or GenericMethodReference).ToList();
                 
                 ConstantDefinition? matchingConstant = null;
@@ -39,12 +33,8 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
                 {
                     var managedBaseMethod = m.BaseMethod.AsManaged();
                     
-                    
-
                     matchingConstant = genericMethodConstants.LastOrDefault(conMtd =>
                     {
-                        // if (conMtd.Value is MethodDefinition methodDefinition)
-                        //     return methodDefinition.Resolve() == managedBaseMethod.Resolve();
                         if (conMtd.Value is MethodReference methodReference)
                             return methodReference.Resolve() == managedBaseMethod.Resolve();
                         return ((GenericMethodReference) conMtd.Value).Method.Resolve() == managedBaseMethod.Resolve();

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/EqualRegisterSetAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/EqualRegisterSetAction.cs
@@ -1,0 +1,28 @@
+﻿using Cpp2IL.Core.Analysis.ResultModels;
+using Mono.Cecil.Cil;
+using Instruction = Iced.Intel.Instruction;
+
+namespace Cpp2IL.Core.Analysis.Actions.x86.Important
+{
+    public class EqualRegisterSetAction : ConditionalRegisterSetAction
+    {
+        public EqualRegisterSetAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
+        {
+        }
+
+        protected override string GetTextSummaryCondition()
+        {
+            return $"{_associatedCompare?.ArgumentOne?.GetPseudocodeRepresentation()} is equal to {_associatedCompare?.ArgumentTwo?.GetPseudocodeRepresentation()}";
+        }
+
+        protected override string GetPseudocodeCondition()
+        {
+            return $"{_associatedCompare?.ArgumentOne?.GetPseudocodeRepresentation()} == {_associatedCompare?.ArgumentTwo?.GetPseudocodeRepresentation()}";
+        }
+
+        protected override Mono.Cecil.Cil.Instruction GetComparisonIl(MethodAnalysis<Instruction> context, ILProcessor processor)
+        {
+            return processor.Create(OpCodes.Ceq);
+        }
+    }
+}

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/Implicit4ByteFieldReadAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/Implicit4ByteFieldReadAction.cs
@@ -50,9 +50,13 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
 
             //Load object
             ret.AddRange(_readOn.GetILToLoad(context, processor));
-
+            
+            var isEnum = _readOn.Type?.Resolve()?.IsEnum;
+            
+            // Let's not do this for enums since it generates some funny garbage
+            if(isEnum != true)
             //Access field
-            ret.AddRange(_read.GetILToLoad(processor));
+                ret.AddRange(_read.GetILToLoad(processor));
 
             //Store to local
             ret.Add(processor.Create(OpCodes.Stloc, _localMade.Variable));

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/LessThanRegisterSetAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/LessThanRegisterSetAction.cs
@@ -1,0 +1,29 @@
+﻿using System.Diagnostics;
+using Cpp2IL.Core.Analysis.ResultModels;
+using Mono.Cecil.Cil;
+using Instruction = Iced.Intel.Instruction;
+
+namespace Cpp2IL.Core.Analysis.Actions.x86.Important
+{
+    public class LessThanRegisterSetAction : ConditionalRegisterSetAction
+    {
+        public LessThanRegisterSetAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
+        {
+        }
+
+        protected override string GetTextSummaryCondition()
+        {
+            return $"{_associatedCompare?.ArgumentOne?.GetPseudocodeRepresentation()} is less than {_associatedCompare?.ArgumentTwo?.GetPseudocodeRepresentation()}";
+        }
+
+        protected override string GetPseudocodeCondition()
+        {
+            return $"{_associatedCompare?.ArgumentOne?.GetPseudocodeRepresentation()} < {_associatedCompare?.ArgumentTwo?.GetPseudocodeRepresentation()}";
+        }
+
+        protected override Mono.Cecil.Cil.Instruction GetComparisonIl(MethodAnalysis<Instruction> context, ILProcessor processor)
+        {
+            return processor.Create(OpCodes.Clt);
+        }
+    }
+}

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/MultiplyRegByRegAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/MultiplyRegByRegAction.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using Cpp2IL.Core.Analysis.Actions.Base;
+using Cpp2IL.Core.Analysis.ResultModels;
+using Mono.Cecil.Cil;
+using Instruction = Iced.Intel.Instruction;
+
+namespace Cpp2IL.Core.Analysis.Actions.x86.Important
+{
+    public class MultiplyRegByRegAction: BaseAction<Instruction>
+    {
+        private string _operandOneReg;
+        private string _operandZeroReg;
+        private LocalDefinition? _operandOneLocal;
+        private LocalDefinition? _operandZeroLocal;
+        private LocalDefinition? _localMade;
+        public MultiplyRegByRegAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
+        {
+            _operandOneReg = Utils.Utils.GetRegisterNameNew(instruction.Op1Register);
+            _operandZeroReg = Utils.Utils.GetRegisterNameNew(instruction.Op0Register);
+            _operandOneLocal = context.GetLocalInReg(_operandOneReg);
+            _operandZeroLocal = context.GetLocalInReg(_operandZeroReg);
+            
+            if(_operandZeroLocal?.Type == null || _operandOneLocal == null)
+                return;
+            
+            RegisterUsedLocal(_operandZeroLocal, context);
+            RegisterUsedLocal(_operandOneLocal, context);
+
+            _localMade = context.MakeLocal(_operandZeroLocal.Type, reg: _operandZeroReg);
+
+        }
+
+        public override Mono.Cecil.Cil.Instruction[] ToILInstructions(MethodAnalysis<Instruction> context, ILProcessor processor)
+        {
+            if (_operandZeroLocal == null || _operandOneLocal == null)
+                throw new TaintedInstructionException("Missing at least one local operand");
+
+            if (_localMade?.Variable == null)
+                throw new TaintedInstructionException("Local made was stripped");
+
+            List<Mono.Cecil.Cil.Instruction> result = new ();
+            
+            result.AddRange(_operandZeroLocal.GetILToLoad(context, processor));
+            result.AddRange(_operandOneLocal.GetILToLoad(context, processor));
+            result.Add(processor.Create(OpCodes.Mul));
+            result.Add(processor.Create(OpCodes.Stloc, _localMade.Variable));
+
+            return result.ToArray();
+        }
+
+        public override bool IsImportant() => true;
+
+        public override string? ToPsuedoCode()
+        {
+            return $"{_operandZeroLocal?.Type?.FullName} {_localMade?.Name} = {_operandZeroLocal?.Name} * {_operandOneLocal?.Name}";
+        }
+
+        public override string ToTextSummary()
+        {
+            return $"Multiplies {_operandZeroLocal?.Name} ({_operandZeroReg}) by {_operandOneLocal?.Name} ({_operandOneReg}) and stores the result in {_localMade?.Name} ({_operandZeroReg})";
+        }
+    }
+}

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/MultiplyRegByRegAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/MultiplyRegByRegAction.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Cpp2IL.Core.Analysis.Actions.Base;
 using Cpp2IL.Core.Analysis.ResultModels;
+using Cpp2IL.Core.Utils;
 using Mono.Cecil.Cil;
 using Instruction = Iced.Intel.Instruction;
 
@@ -15,8 +16,8 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
         private LocalDefinition? _localMade;
         public MultiplyRegByRegAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
         {
-            _operandOneReg = Utils.Utils.GetRegisterNameNew(instruction.Op1Register);
-            _operandZeroReg = Utils.Utils.GetRegisterNameNew(instruction.Op0Register);
+            _operandOneReg = X86Utils.GetRegisterNameNew(instruction.Op1Register);
+            _operandZeroReg = X86Utils.GetRegisterNameNew(instruction.Op0Register);
             _operandOneLocal = context.GetLocalInReg(_operandOneReg);
             _operandZeroLocal = context.GetLocalInReg(_operandZeroReg);
             

--- a/Cpp2IL.Core/Analysis/Actions/x86/PlusOneOrMinusOneAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/PlusOneOrMinusOneAction.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Cpp2IL.Core.Analysis.Actions.Base;
 using Cpp2IL.Core.Analysis.ResultModels;
+using Cpp2IL.Core.Utils;
 using Mono.Cecil.Cil;
 using Instruction = Iced.Intel.Instruction;
 
@@ -15,9 +16,9 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
 
         public PlusOneOrMinusOneAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
         {
-            string destReg = Utils.Utils.GetRegisterNameNew(instruction.Op0Register);
+            string destReg = X86Utils.GetRegisterNameNew(instruction.Op0Register);
 
-            string regBeingAddedTo = Utils.Utils.GetRegisterNameNew(instruction.MemoryBase);
+            string regBeingAddedTo = X86Utils.GetRegisterNameNew(instruction.MemoryBase);
 
             _localBeingAddedTo = context.GetLocalInReg(regBeingAddedTo);
 

--- a/Cpp2IL.Core/Analysis/Actions/x86/PlusOneOrMinusOneAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/PlusOneOrMinusOneAction.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Cpp2IL.Core.Analysis.Actions.Base;
+using Cpp2IL.Core.Analysis.ResultModels;
+using Mono.Cecil.Cil;
+using Instruction = Iced.Intel.Instruction;
+
+namespace Cpp2IL.Core.Analysis.Actions.x86
+{
+    public class PlusOneOrMinusOneAction : BaseAction<Instruction>
+    {
+        private LocalDefinition? _localBeingAddedTo;
+        private LocalDefinition? _localMade;
+        private bool Adding;
+
+        public PlusOneOrMinusOneAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
+        {
+            string destReg = Utils.Utils.GetRegisterNameNew(instruction.Op0Register);
+
+            string regBeingAddedTo = Utils.Utils.GetRegisterNameNew(instruction.MemoryBase);
+
+            _localBeingAddedTo = context.GetLocalInReg(regBeingAddedTo);
+
+            if (_localBeingAddedTo?.Type == null) return;
+
+            _localMade = context.MakeLocal(_localBeingAddedTo.Type, reg: destReg);
+
+            RegisterUsedLocal(_localBeingAddedTo, context);
+
+
+            if ((long)instruction.MemoryDisplacement64 == 1)
+                Adding = true;
+        }
+
+        public override bool IsImportant() => true;
+
+        public override Mono.Cecil.Cil.Instruction[] ToILInstructions(MethodAnalysis<Instruction> context, ILProcessor processor)
+        {
+            if (_localBeingAddedTo == null)
+                throw new TaintedInstructionException("Local being added to was null");
+
+            if (_localMade?.Variable == null)
+                throw new TaintedInstructionException("Local made was stripped");    
+            
+            List<Mono.Cecil.Cil.Instruction> instructions = new();
+            
+            if (Adding)
+            {
+                instructions.AddRange(_localBeingAddedTo.GetILToLoad(context, processor));
+                instructions.Add(Mono.Cecil.Cil.Instruction.Create(OpCodes.Ldc_I4_1));
+                instructions.Add(Mono.Cecil.Cil.Instruction.Create(OpCodes.Add));
+                instructions.Add(Mono.Cecil.Cil.Instruction.Create(OpCodes.Stloc, _localMade.Variable));
+            }
+            else
+            {
+                instructions.AddRange(_localBeingAddedTo.GetILToLoad(context, processor));
+                instructions.Add(Mono.Cecil.Cil.Instruction.Create(OpCodes.Ldc_I4_1));
+                instructions.Add(Mono.Cecil.Cil.Instruction.Create(OpCodes.Sub));
+                instructions.Add(Mono.Cecil.Cil.Instruction.Create(OpCodes.Stloc, _localMade.Variable));
+            }
+
+            return instructions.ToArray();
+        }
+
+        public override string? ToPsuedoCode()
+        {
+            return $"{_localMade?.Type?.FullName} {_localMade?.Name} = {_localBeingAddedTo?.Name} {(Adding ? "+" : "-")} 1";
+        }
+
+        public override string ToTextSummary()
+        {
+           return $"{(Adding ? "Adds" : "Subtracts")} 1 {(Adding ? "to" : "from")} {_localBeingAddedTo?.Name} and stores the result in {_localMade?.Name}";
+        }
+    }
+}

--- a/Cpp2IL.Core/Analysis/Actions/x86/ReadLocalPointerToRegAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/ReadLocalPointerToRegAction.cs
@@ -14,7 +14,7 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
         private LocalDefinition? _localMade;
         public ReadLocalPointerToRegAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
         {
-            LocalPointer = context.GetConstantInReg(X86Utils.GetRegisterNameNew(instruction.MemoryBase)).Value as LocalPointer;
+            LocalPointer = context.GetConstantInReg(X86Utils.GetRegisterNameNew(instruction.MemoryBase))?.Value as LocalPointer;
 
             if (LocalPointer == null)
                 return;
@@ -57,7 +57,7 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
 
         public override string ToTextSummary()
         {
-            return $"Dereference and move local {LocalPointer?.Local?.Name} to {_localMade?.Name}";
+            return $"Dereference and moves local {LocalPointer?.Local?.Name} to {_localMade?.Name}";
         }
     }
 }

--- a/Cpp2IL.Core/Analysis/Actions/x86/ReadLocalPointerToRegAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/ReadLocalPointerToRegAction.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using Cpp2IL.Core.Analysis.Actions.Base;
 using Cpp2IL.Core.Analysis.ResultModels;
+using Cpp2IL.Core.Utils;
 using Instruction = Iced.Intel.Instruction;
 using Mono.Cecil.Cil;
 
@@ -13,7 +14,7 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
         private LocalDefinition? _localMade;
         public ReadLocalPointerToRegAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
         {
-            LocalPointer = context.GetConstantInReg(Utils.Utils.GetRegisterNameNew(instruction.MemoryBase)).Value as LocalPointer;
+            LocalPointer = context.GetConstantInReg(X86Utils.GetRegisterNameNew(instruction.MemoryBase)).Value as LocalPointer;
 
             if (LocalPointer == null)
                 return;
@@ -21,7 +22,7 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
             
             RegisterUsedLocal(LocalPointer.Local, context);
             
-            string destReg = Utils.Utils.GetRegisterNameNew(instruction.Op0Register);
+            string destReg = X86Utils.GetRegisterNameNew(instruction.Op0Register);
 
             if(LocalPointer.Local.Type != null)
                 _localMade = context.MakeLocal(LocalPointer.Local.Type, reg: destReg);

--- a/Cpp2IL.Core/Analysis/Actions/x86/ReadLocalPointerToRegAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/ReadLocalPointerToRegAction.cs
@@ -1,0 +1,63 @@
+﻿using System.Diagnostics;
+using Cpp2IL.Core.Analysis.Actions.Base;
+using Cpp2IL.Core.Analysis.ResultModels;
+using Instruction = Iced.Intel.Instruction;
+using Mono.Cecil.Cil;
+
+
+namespace Cpp2IL.Core.Analysis.Actions.x86
+{
+    public class ReadLocalPointerToRegAction : BaseAction<Instruction>
+    {
+        private LocalPointer? LocalPointer;
+        private LocalDefinition? _localMade;
+        public ReadLocalPointerToRegAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
+        {
+            Debugger.Break();
+            LocalPointer = context.GetConstantInReg(Utils.Utils.GetRegisterNameNew(instruction.MemoryBase)).Value as LocalPointer;
+
+            if (LocalPointer == null)
+                return;
+            
+            
+            RegisterUsedLocal(LocalPointer.Local, context);
+            
+            string destReg = Utils.Utils.GetRegisterNameNew(instruction.Op0Register);
+
+            if(LocalPointer.Local.Type != null)
+                _localMade = context.MakeLocal(LocalPointer.Local.Type, reg: destReg);
+            
+           
+        }
+
+        public override bool IsImportant()
+        {
+            return true;
+        }
+
+        public override Mono.Cecil.Cil.Instruction[] ToILInstructions(MethodAnalysis<Instruction> context, ILProcessor processor)
+        {
+            if (LocalPointer?.Local == null)
+                throw new TaintedInstructionException("Local being dereferenced was null");
+            
+            if (_localMade?.Variable == null)
+                throw new TaintedInstructionException("Local was stripped");
+            
+            
+            return new[]
+            {
+                context.GetIlToLoad(LocalPointer.Local, processor),
+                processor.Create(OpCodes.Stloc, _localMade.Variable)
+            };
+        }
+        public override string? ToPsuedoCode()
+        {
+            return $"{_localMade?.Name} = {LocalPointer?.Local?.Name}";
+        }
+
+        public override string ToTextSummary()
+        {
+            return $"Dereference and move local {LocalPointer?.Local?.Name} to {_localMade?.Name}";
+        }
+    }
+}

--- a/Cpp2IL.Core/Analysis/Actions/x86/ReadLocalPointerToRegAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/ReadLocalPointerToRegAction.cs
@@ -13,7 +13,6 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
         private LocalDefinition? _localMade;
         public ReadLocalPointerToRegAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
         {
-            Debugger.Break();
             LocalPointer = context.GetConstantInReg(Utils.Utils.GetRegisterNameNew(instruction.MemoryBase)).Value as LocalPointer;
 
             if (LocalPointer == null)
@@ -37,8 +36,8 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
 
         public override Mono.Cecil.Cil.Instruction[] ToILInstructions(MethodAnalysis<Instruction> context, ILProcessor processor)
         {
-            if (LocalPointer?.Local == null)
-                throw new TaintedInstructionException("Local being dereferenced was null");
+            if (LocalPointer?.Local?.Variable == null)
+                throw new TaintedInstructionException("Local being dereferenced was stripped");
             
             if (_localMade?.Variable == null)
                 throw new TaintedInstructionException("Local was stripped");

--- a/Cpp2IL.Core/Analysis/Actions/x86/UnboxObjectAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/UnboxObjectAction.cs
@@ -1,0 +1,52 @@
+﻿using Cpp2IL.Core.Analysis.Actions.Base;
+using Cpp2IL.Core.Analysis.ResultModels;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Instruction = Iced.Intel.Instruction;
+
+namespace Cpp2IL.Core.Analysis.Actions.x86
+{
+    public class UnboxObjectAction : BaseAction<Instruction>
+    {
+        private TypeReference? destinationType;
+        private LocalDefinition? localBeingUnboxed;
+        private LocalDefinition? _localMade;
+        private bool _boxingFieldPointer = false;
+        private FieldPointer _boxedField;
+
+        public UnboxObjectAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
+        {
+            //TODO 32-bit, stack is different, need to pop instead of rdx, etc.
+            localBeingUnboxed = context.GetLocalInReg("rcx");
+
+            if (localBeingUnboxed == null)
+                return;
+            
+            RegisterUsedLocal(localBeingUnboxed, context);
+            
+            _localMade = context.MakeLocal(destinationType, reg: "rax");
+        }
+        public override bool IsImportant() => true;
+
+        public override Mono.Cecil.Cil.Instruction[] ToILInstructions(MethodAnalysis<Instruction> context, ILProcessor processor)
+        {
+            if (localBeingUnboxed == null || _localMade == null)
+                throw new TaintedInstructionException("Local being unboxed or local created was null");
+            
+            return new[]
+            {
+                context.GetIlToLoad(localBeingUnboxed!, processor),
+                processor.Create(OpCodes.Stloc, _localMade.Variable)
+            };
+        }
+        public override string? ToPsuedoCode()
+        {
+            return $"{_localMade.Name} = {localBeingUnboxed.Name}";
+        }
+
+        public override string ToTextSummary()
+        {
+            return $"Unboxes local {localBeingUnboxed.Name} to {_localMade.Name}";
+        }
+    }
+}

--- a/Cpp2IL.Core/Analysis/Actions/x86/UnboxObjectAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/UnboxObjectAction.cs
@@ -9,12 +9,8 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
 {
     public class UnboxObjectAction : BaseAction<Instruction>
     {
-        private TypeReference? destinationType;
         private LocalDefinition? localBeingUnboxed;
-        private LocalDefinition? _localMade;
-        private bool _boxingFieldPointer = false;
-        private FieldPointer? _boxedField;
-        private ConstantDefinition ConstantDefinition;
+        private ConstantDefinition? ConstantDefinition;
 
         public UnboxObjectAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
         {

--- a/Cpp2IL.Core/Analysis/Actions/x86/UnboxObjectAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/UnboxObjectAction.cs
@@ -1,4 +1,5 @@
-﻿using Cpp2IL.Core.Analysis.Actions.Base;
+﻿using System;
+using Cpp2IL.Core.Analysis.Actions.Base;
 using Cpp2IL.Core.Analysis.ResultModels;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -12,7 +13,8 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
         private LocalDefinition? localBeingUnboxed;
         private LocalDefinition? _localMade;
         private bool _boxingFieldPointer = false;
-        private FieldPointer _boxedField;
+        private FieldPointer? _boxedField;
+        private ConstantDefinition ConstantDefinition;
 
         public UnboxObjectAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
         {
@@ -24,29 +26,25 @@ namespace Cpp2IL.Core.Analysis.Actions.x86
             
             RegisterUsedLocal(localBeingUnboxed, context);
             
-            _localMade = context.MakeLocal(destinationType, reg: "rax");
+            ConstantDefinition = context.MakeConstant(typeof(LocalPointer), new LocalPointer(localBeingUnboxed), reg: "rax");
+            
+            //_localMade = context.MakeLocal(destinationType, reg: "rax");
         }
-        public override bool IsImportant() => true;
+        public override bool IsImportant() => false;
 
         public override Mono.Cecil.Cil.Instruction[] ToILInstructions(MethodAnalysis<Instruction> context, ILProcessor processor)
         {
-            if (localBeingUnboxed == null || _localMade == null)
-                throw new TaintedInstructionException("Local being unboxed or local created was null");
-            
-            return new[]
-            {
-                context.GetIlToLoad(localBeingUnboxed!, processor),
-                processor.Create(OpCodes.Stloc, _localMade.Variable)
-            };
+            throw new NotImplementedException();
         }
         public override string? ToPsuedoCode()
         {
+            throw new NotImplementedException();
             return $"{_localMade.Name} = {localBeingUnboxed.Name}";
         }
 
         public override string ToTextSummary()
         {
-            return $"Unboxes local {localBeingUnboxed.Name} to {_localMade.Name}";
+            return "";
         }
     }
 }

--- a/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
+++ b/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
@@ -559,6 +559,10 @@ namespace Cpp2IL.Core.Analysis
                         Analysis.Actions.Add(MaybeWrap(new LoadClassPointerFromMethodInfoAction(Analysis, instruction)));
                     }
 
+                    break; 
+                case Mnemonic.Mov when type1 == OpKind.Memory && type0 == OpKind.Register && memR != "rip" && instruction.MemoryIndex == Register.None && memOp is ConstantDefinition {Value: LocalPointer}:
+                    //Read local pointer
+                    Analysis.Actions.Add(MaybeWrap(new ReadLocalPointerToRegAction(Analysis, instruction)));
                     break;
                 case Mnemonic.Mov when type1 == OpKind.Memory && type0 == OpKind.Register && memR != "rip" && instruction.MemoryIndex == Register.None && memOp is LocalDefinition loc:
                     //Move generic memory to register - field read.

--- a/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
+++ b/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
@@ -582,13 +582,15 @@ namespace Cpp2IL.Core.Analysis
                     //LEA generic memory to register - field pointer load.
 
                     var displacement = (long) instruction.MemoryDisplacement64;
-                    if (displacement == 1 || displacement == -1 )
+                    if (displacement == 1 || displacement == -1)
                     {
-                        if (localDefinition.Type.FullName.Equals("System.Int32") ||
+                        if (localDefinition.Type is {} && (
+
+                            localDefinition.Type.FullName.Equals("System.Int32") ||
                             localDefinition.Type.FullName.Equals("System.Int64") ||
                             localDefinition.Type.FullName.Equals("System.UInt32") ||
                             localDefinition.Type.FullName.Equals("System.UInt64") ||
-                            localDefinition.Type.FullName.Equals("System.Byte"))
+                            localDefinition.Type.FullName.Equals("System.Byte")))
                         {
                             // Plus 1 or minus 1 action
                             Analysis.Actions.Add(new PlusOneOrMinusOneAction(Analysis, instruction));

--- a/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
+++ b/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
@@ -175,6 +175,10 @@ namespace Cpp2IL.Core.Analysis
                         //Box a cpp primitive to a managed type
                         Analysis.Actions.Add(new BoxValueAction(Analysis, instruction));
                     }
+                    else if (jumpTarget == _keyFunctionAddresses.il2cpp_object_unbox || jumpTarget == _keyFunctionAddresses.il2cpp_vm_object_unbox)
+                    {
+                        Analysis.Actions.Add(new UnboxObjectAction(Analysis, instruction));
+                    }
                     else if (jumpTarget == _keyFunctionAddresses.il2cpp_object_is_inst)
                     {
                         //Safe cast an object to a type

--- a/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
+++ b/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
@@ -579,29 +579,15 @@ namespace Cpp2IL.Core.Analysis
                     Analysis.Actions.Add(MaybeWrap(new FieldToLocalAction(Analysis, instruction)));
                     break;
                 case Mnemonic.Lea when type1 == OpKind.Memory && type0 == OpKind.Register && memR != "rip" && memOp is LocalDefinition localDefinition && instruction.MemoryIndex == Register.None:
-                    //LEA generic memory to register - field pointer load.
-
-                    var displacement = (long) instruction.MemoryDisplacement64;
-                    if (displacement == 1 || displacement == -1)
+                    
+                    if (localDefinition.Type is {IsPrimitive: true} && ((long)instruction.MemoryDisplacement64) is 1 or -1)
                     {
-                        if (localDefinition.Type is {} && (
-
-                            localDefinition.Type.FullName.Equals("System.Int32") ||
-                            localDefinition.Type.FullName.Equals("System.Int64") ||
-                            localDefinition.Type.FullName.Equals("System.UInt32") ||
-                            localDefinition.Type.FullName.Equals("System.UInt64") ||
-                            localDefinition.Type.FullName.Equals("System.Byte")))
-                        {
-                            // Plus 1 or minus 1 action
-                            Analysis.Actions.Add(new PlusOneOrMinusOneAction(Analysis, instruction));
-                        }
-                        else
-                        {
-                            Analysis.Actions.Add(new FieldPointerToRegAction(Analysis, instruction));
-                        }
+                        // Plus 1 or minus 1 action
+                        Analysis.Actions.Add(new PlusOneOrMinusOneAction(Analysis, instruction));
                     }
                     else
                     {
+                        //LEA generic memory to register - field pointer load.
                         Analysis.Actions.Add(new FieldPointerToRegAction(Analysis, instruction));
                     }
                     

--- a/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
+++ b/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
@@ -303,7 +303,6 @@ namespace Cpp2IL.Core.Analysis
 
             if (mnemonic == Mnemonic.Comiss)
                 mnemonic = Mnemonic.Cmp;
-            
             //Noting here, format of a memory operand is:
             //[memoryBase + memoryIndex * memoryIndexScale + memoryOffset]
             
@@ -321,7 +320,6 @@ namespace Cpp2IL.Core.Analysis
                             break;
                         }
                     }
-
                     //Fallback to a reg->reg move.
                     Analysis.Actions.Add(MaybeWrap(new RegToRegMoveAction(Analysis, instruction)));
                     break;
@@ -665,6 +663,10 @@ namespace Cpp2IL.Core.Analysis
                     //But value in reg is the first step of an integer division
                     //So this is step 2
                     Analysis.Actions.Add(new IntegerDivisionShiftStepAction(Analysis, instruction));
+                    break;
+                case Mnemonic.Imul when op0 is LocalDefinition && op1 is LocalDefinition:
+                    //Imul reg, reg
+                    Analysis.Actions.Add(new MultiplyRegByRegAction(Analysis, instruction));
                     break;
             }
         }

--- a/Cpp2IL.Core/Analysis/ResultModels/LocalPointer.cs
+++ b/Cpp2IL.Core/Analysis/ResultModels/LocalPointer.cs
@@ -1,0 +1,11 @@
+﻿namespace Cpp2IL.Core.Analysis.ResultModels
+{
+    public class LocalPointer
+    {
+        public readonly LocalDefinition Local;
+        public LocalPointer(LocalDefinition localDefinition)
+        {
+            Local = localDefinition;
+        }
+    }
+}

--- a/Cpp2IL.Core/Utils/GenericMethodUtils.cs
+++ b/Cpp2IL.Core/Utils/GenericMethodUtils.cs
@@ -25,7 +25,7 @@ namespace Cpp2IL.Core.Utils
             if(theMethod is MethodDefinition && declaringType is TypeDefinition)
                 return;
             
-            Debugger.Break();
+            //Debugger.Break();
         }
     }
 }

--- a/Cpp2IL.Core/Utils/MethodUtils.cs
+++ b/Cpp2IL.Core/Utils/MethodUtils.cs
@@ -400,7 +400,7 @@ namespace Cpp2IL.Core.Utils
                 catch (Exception)
                 {
                     if (usage != null)
-                        return SharedState.UnmanagedToManagedMethods[usage.AsGenericMethodRef().baseMethod];
+                        return SharedState.UnmanagedToManagedMethods[usage.AsGenericMethodRef().BaseMethod];
                 }
             }
             catch (IndexOutOfRangeException)
@@ -424,7 +424,7 @@ namespace Cpp2IL.Core.Utils
                 }
                 catch (Exception)
                 {
-                    concreteMethod = concreteUsage!.AsGenericMethodRef().baseMethod;
+                    concreteMethod = concreteUsage!.AsGenericMethodRef().BaseMethod;
                 }
 
                 Il2CppMethodDefinition? unmanagedMethod = null;

--- a/Cpp2IL.Core/Utils/MethodUtils.cs
+++ b/Cpp2IL.Core/Utils/MethodUtils.cs
@@ -392,8 +392,16 @@ namespace Cpp2IL.Core.Utils
             {
                 var usage = klass.VTable[slotNum];
 
-                if (usage != null)
-                    return SharedState.UnmanagedToManagedMethods[usage.AsMethod()];
+                try
+                {
+                    if (usage != null)
+                        return SharedState.UnmanagedToManagedMethods[usage.AsMethod()];
+                }
+                catch (Exception)
+                {
+                    if (usage != null)
+                        return SharedState.UnmanagedToManagedMethods[usage.AsGenericMethodRef().baseMethod];
+                }
             }
             catch (IndexOutOfRangeException)
             {
@@ -409,7 +417,15 @@ namespace Cpp2IL.Core.Utils
             try
             {
                 var concreteUsage = concrete.VTable[slotNum];
-                var concreteMethod = concreteUsage!.AsMethod();
+                Il2CppMethodDefinition concreteMethod;
+                try
+                {
+                    concreteMethod = concreteUsage!.AsMethod();
+                }
+                catch (Exception)
+                {
+                    concreteMethod = concreteUsage!.AsGenericMethodRef().baseMethod;
+                }
 
                 Il2CppMethodDefinition? unmanagedMethod = null;
                 var thisType = klass;


### PR DESCRIPTION
- Support for imul reg, reg.
- Avoid generating bad il for enums in Implicit4ByteFieldReadAction
- Allow locals to be used for array size
- Allowing the box action to be used on field pointers
- Added an unbox action which stores a pointer to a local in a reg. (Which in turn is can be used by the ReadLocalPointerToRegAction). This could probably be improved/rewritten in a better way.
- Allowing GenericMethodReferences in the CallManagedFunction to be used as constants to identify the correct concrete method. I understand that you want to improve generic methods in general and this is a bit a bit of a hack to get more generics to work, so it might be better if this is removed and proper support for it is added later
- Support for sete and setl x86 instructions
- Support for quick(?) addition done through lea reg, [reg+/-1]. This could be extended further to support immediates other than 1