### PR TITLE
Add support for x86 Setne instruction

### DIFF
--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/ConditionalRegisterSetAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/ConditionalRegisterSetAction.cs
@@ -26,7 +26,7 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
         
         protected abstract string GetPseudocodeCondition();
 
-        protected abstract Mono.Cecil.Cil.Instruction GetComparisonIl(MethodAnalysis<Instruction> context, ILProcessor processor);
+        protected abstract Mono.Cecil.Cil.Instruction[] GetComparisonIl(MethodAnalysis<Instruction> context, ILProcessor processor);
 
         public override Mono.Cecil.Cil.Instruction[] ToILInstructions(MethodAnalysis<Instruction> context, ILProcessor processor)
         {
@@ -41,7 +41,7 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
             ret.AddRange(_associatedCompare.ArgumentOne.GetILToLoad(context, processor));
             ret.AddRange(_associatedCompare.ArgumentTwo.GetILToLoad(context, processor));
             
-            ret.Add(GetComparisonIl(context, processor));
+            ret.AddRange(GetComparisonIl(context, processor));
             
             ret.Add(processor.Create(OpCodes.Stloc, _localMade.Variable));
             

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/EqualRegisterSetAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/EqualRegisterSetAction.cs
@@ -20,9 +20,9 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
             return $"{_associatedCompare?.ArgumentOne?.GetPseudocodeRepresentation()} == {_associatedCompare?.ArgumentTwo?.GetPseudocodeRepresentation()}";
         }
 
-        protected override Mono.Cecil.Cil.Instruction GetComparisonIl(MethodAnalysis<Instruction> context, ILProcessor processor)
+        protected override Mono.Cecil.Cil.Instruction[] GetComparisonIl(MethodAnalysis<Instruction> context, ILProcessor processor)
         {
-            return processor.Create(OpCodes.Ceq);
+            return new[] { processor.Create(OpCodes.Ceq) };
         }
     }
 }

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/GreaterThanRegisterSetAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/GreaterThanRegisterSetAction.cs
@@ -20,9 +20,9 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
             return $"{_associatedCompare?.ArgumentOne?.GetPseudocodeRepresentation()} > {_associatedCompare?.ArgumentTwo?.GetPseudocodeRepresentation()}";
         }
 
-        protected override Mono.Cecil.Cil.Instruction GetComparisonIl(MethodAnalysis<Instruction> context, ILProcessor processor)
+        protected override Mono.Cecil.Cil.Instruction[] GetComparisonIl(MethodAnalysis<Instruction> context, ILProcessor processor)
         {
-            return processor.Create(OpCodes.Cgt);
+            return new[] { processor.Create(OpCodes.Cgt)};
         }
     }
 }

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/LessThanRegisterSetAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/LessThanRegisterSetAction.cs
@@ -21,9 +21,9 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
             return $"{_associatedCompare?.ArgumentOne?.GetPseudocodeRepresentation()} < {_associatedCompare?.ArgumentTwo?.GetPseudocodeRepresentation()}";
         }
 
-        protected override Mono.Cecil.Cil.Instruction GetComparisonIl(MethodAnalysis<Instruction> context, ILProcessor processor)
+        protected override Mono.Cecil.Cil.Instruction[] GetComparisonIl(MethodAnalysis<Instruction> context, ILProcessor processor)
         {
-            return processor.Create(OpCodes.Clt);
+            return new []{processor.Create(OpCodes.Clt)};
         }
     }
 }

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/NotEqualRegisterSetAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/NotEqualRegisterSetAction.cs
@@ -1,6 +1,5 @@
 ﻿using Cpp2IL.Core.Analysis.ResultModels;
 using Mono.Cecil.Cil;
-using MonoMod.Utils;
 using Instruction = Iced.Intel.Instruction;
 
 namespace Cpp2IL.Core.Analysis.Actions.x86.Important

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/NotEqualRegisterSetAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/NotEqualRegisterSetAction.cs
@@ -1,0 +1,34 @@
+﻿using Cpp2IL.Core.Analysis.ResultModels;
+using Mono.Cecil.Cil;
+using MonoMod.Utils;
+using Instruction = Iced.Intel.Instruction;
+
+namespace Cpp2IL.Core.Analysis.Actions.x86.Important
+{
+    public class NotEqualRegisterSetAction : ConditionalRegisterSetAction
+    {
+        public NotEqualRegisterSetAction(MethodAnalysis<Instruction> context, Instruction instruction) : base(context, instruction)
+        {
+        }
+
+        protected override string GetTextSummaryCondition()
+        {
+            return $"{_associatedCompare?.ArgumentOne?.GetPseudocodeRepresentation()} isn't equal to {_associatedCompare?.ArgumentTwo?.GetPseudocodeRepresentation()}";
+        }
+
+        protected override string GetPseudocodeCondition()
+        {
+            return $"{_associatedCompare?.ArgumentOne?.GetPseudocodeRepresentation()} != {_associatedCompare?.ArgumentTwo?.GetPseudocodeRepresentation()}";
+        }
+
+        protected override Mono.Cecil.Cil.Instruction[] GetComparisonIl(MethodAnalysis<Instruction> context, ILProcessor processor)
+        {
+            return new []
+            {
+                processor.Create(OpCodes.Ceq),
+                processor.Create(OpCodes.Ldc_I4_0),
+                processor.Create(OpCodes.Ceq)
+            };
+        }
+    }
+}

--- a/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
+++ b/Cpp2IL.Core/Analysis/AsmAnalyzerX86.InstructionChecks.cs
@@ -258,6 +258,9 @@ namespace Cpp2IL.Core.Analysis
                 case Mnemonic.Sete:
                     Analysis.Actions.Add(new EqualRegisterSetAction(Analysis, instruction));
                     break;
+                case Mnemonic.Setne:
+                    Analysis.Actions.Add(new NotEqualRegisterSetAction(Analysis, instruction));
+                    break;
                 case Mnemonic.Setg:
                     Analysis.Actions.Add(new GreaterThanRegisterSetAction(Analysis, instruction));
                     break;


### PR DESCRIPTION
Adds support for Setne instruction which required tweaking ConditionalRegisterSetAction so that GetComparisonIl supports not just a single instruction