### PR TITLE
x86: Fix issue with Test instruction 

### DIFF
--- a/Cpp2IL.Core/Analysis/Actions/Base/AbstractComparisonAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/Base/AbstractComparisonAction.cs
@@ -14,8 +14,8 @@ namespace Cpp2IL.Core.Analysis.Actions.Base
         public IComparisonArgument? ArgumentOne;
         public IComparisonArgument? ArgumentTwo;
         
-        private readonly string? ArgumentOneRegister;
-        private readonly string? ArgumentTwoRegister;
+        protected readonly string? ArgumentOneRegister;
+        protected readonly string? ArgumentTwoRegister;
         
         public bool UnimportantComparison;
         public ulong EndOfLoopAddr;
@@ -42,6 +42,9 @@ namespace Cpp2IL.Core.Analysis.Actions.Base
             {
                 ArgumentTwo = ExtractArgument(context, associatedInstruction, 1, out unimportant2, out ArgumentTwoRegister);
 
+                // ReSharper disable once VirtualMemberCallInConstructor
+                OnSecondArgumentExtracted(context);
+                
                 if (ArgumentTwo is ConstantDefinition { Value: UnknownGlobalAddr globalAddr2 } cons2 && ArgumentOne is LocalDefinition { Type: { }, KnownInitialValue: null } loc1)
                 {
                     try
@@ -137,6 +140,8 @@ namespace Cpp2IL.Core.Analysis.Actions.Base
         {
             return ArgumentOneRegister == regName ? ArgumentOne : ArgumentTwoRegister == regName ? ArgumentTwo : null;
         }
+
+        protected virtual void OnSecondArgumentExtracted<T>(MethodAnalysis<T> context) { }
 
         protected abstract bool IsMemoryReferenceAnAbsolutePointer(T instruction, int operandIdx);
 

--- a/Cpp2IL.Core/Analysis/Actions/x86/Important/ComparisonAction.cs
+++ b/Cpp2IL.Core/Analysis/Actions/x86/Important/ComparisonAction.cs
@@ -37,5 +37,14 @@ namespace Cpp2IL.Core.Analysis.Actions.x86.Important
 
             return ComparisonOperandType.MEMORY_ADDRESS_OR_OFFSET;
         }
+
+        protected override void OnSecondArgumentExtracted<T>(MethodAnalysis<T> context)
+        {
+            if (AssociatedInstruction.Mnemonic == Mnemonic.Test && ArgumentOneRegister?.Equals(ArgumentTwoRegister) == true)
+            {
+                // test reg, reg is the same thing as doing cmp reg, 0 (just without an immediate)
+                ArgumentTwo = context.MakeConstant(typeof(int), 0);
+            }
+        }
     }
 }


### PR DESCRIPTION
This pr fixes the issue mentioned in #51 by adding a virtual method that the x86 comparison action can implement to correct the arguments of the comparison in the case that its a Test instruction and the register for the first argument matches the register for the second argument.