### PR TITLE
MethodAnalysisContext improvements

### DIFF
--- a/Cpp2IL.Core/CorePlugin/AttributeInjectorProcessingLayer.cs
+++ b/Cpp2IL.Core/CorePlugin/AttributeInjectorProcessingLayer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -80,14 +80,14 @@ public class AttributeInjectorProcessingLayer : Cpp2IlProcessingLayer
 
             foreach (var m in assemblyAnalysisContext.Types.SelectMany(t => t.Methods))
             {
-                if (m.CustomAttributes == null || m.Definition == null)
+                if (m.CustomAttributes == null || m.UnderlyingPointer == 0)
                     continue;
 
                 var newAttribute = new AnalyzedCustomAttribute(addressConstructor);
 
                 if (!_useEzDiffMode)
                 {
-                    newAttribute.Fields.Add(new(rvaField, new CustomAttributePrimitiveParameter($"0x{m.Definition.Rva:X}", newAttribute, CustomAttributeParameterKind.Field, 0)));
+                    newAttribute.Fields.Add(new(rvaField, new CustomAttributePrimitiveParameter($"0x{m.Rva:X}", newAttribute, CustomAttributeParameterKind.Field, 0)));
                     if (appContext.Binary.TryMapVirtualAddressToRaw(m.UnderlyingPointer, out var offset))
                         newAttribute.Fields.Add(new(offsetField, new CustomAttributePrimitiveParameter($"0x{offset:X}", newAttribute, CustomAttributeParameterKind.Field, 1)));
                 }

--- a/Cpp2IL.Core/CorePlugin/CallAnalysisProcessingLayer.cs
+++ b/Cpp2IL.Core/CorePlugin/CallAnalysisProcessingLayer.cs
@@ -59,7 +59,7 @@ public class CallAnalysisProcessingLayer : Cpp2IlProcessingLayer
             foreach (var m in assemblyAnalysisContext.Types.SelectMany(t => t.Methods))
             {
                 m.AnalyzeCustomAttributeData();
-                if (m.CustomAttributes == null || m.Definition == null)
+                if (m.CustomAttributes == null || m.UnderlyingPointer == 0)
                     continue;
 
                 if (appContext.MethodsByAddress.TryGetValue(m.UnderlyingPointer, out var methodsWithThatAddress) && methodsWithThatAddress.Count > 1)
@@ -73,11 +73,12 @@ public class CallAnalysisProcessingLayer : Cpp2IlProcessingLayer
                 }
                 catch
                 {
+                    m.ConvertedIsil = null;
                     AttributeInjectionUtils.AddZeroParameterAttribute(m, analysisFailedConstructor);
                     continue;
                 }
 
-                if (m.ConvertedIsil is null or { Count: 0 })
+                if (m.ConvertedIsil is { Count: 0 })
                 {
                     if ((m.MethodAttributes & MethodAttributes.Abstract) == 0)
                     {
@@ -135,7 +136,7 @@ public class CallAnalysisProcessingLayer : Cpp2IlProcessingLayer
 
             foreach (var m in assemblyAnalysisContext.Types.SelectMany(t => t.Methods))
             {
-                if (m.CustomAttributes == null || m.Definition == null)
+                if (m.CustomAttributes == null || m.UnderlyingPointer == 0)
                     continue;
 
                 var unknownCallCount = unknownCalls.GetOrDefault(m, 0);

--- a/Cpp2IL.Core/Model/Contexts/ApplicationAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/ApplicationAnalysisContext.cs
@@ -163,7 +163,7 @@ public class ApplicationAnalysisContext : ContextWithDataStorage
         return _keyFunctionAddresses;
     }
 
-    public MultiAssemblyInjectedType InjectTypeIntoAllAssemblies(string ns, string name, TypeAnalysisContext baseType)
+    public MultiAssemblyInjectedType InjectTypeIntoAllAssemblies(string ns, string name, TypeAnalysisContext? baseType)
     {
         var types = Assemblies.Select(a => (InjectedTypeAnalysisContext)a.InjectType(ns, name, baseType)).ToArray();
 

--- a/Cpp2IL.Core/Model/Contexts/InjectedMethodAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/InjectedMethodAnalysisContext.cs
@@ -1,9 +1,11 @@
-﻿using System.Reflection;
+using System.Reflection;
 
 namespace Cpp2IL.Core.Model.Contexts;
 
 public class InjectedMethodAnalysisContext : MethodAnalysisContext
 {
+    public override ulong UnderlyingPointer => 0;
+
     public override string DefaultName { get; }
 
     public override bool IsStatic { get; }


### PR DESCRIPTION
* Avoid double analysis of methods
* Use UnderlyingPointer for RVA calculation
* Nullable annotations