### PR TITLE
Fix Invalid IL in Dummy Methods

### DIFF
--- a/Cpp2IL.Core/Cpp2IL.Core.csproj
+++ b/Cpp2IL.Core/Cpp2IL.Core.csproj
@@ -39,13 +39,13 @@
         
         <!--Not used at runtime, but needed for the build-->
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+
+        <PackageReference Include="PolySharp" Version="1.8.1" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
         <!--Supplementary packages to provide modern runtime features on netstandard2-->
         <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-        <PackageReference Include="IndexRange" Version="1.0.2" />
-        <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Cpp2IL.Core/Model/CustomAttributes/BaseCustomAttributeTypeParameter.cs
+++ b/Cpp2IL.Core/Model/CustomAttributes/BaseCustomAttributeTypeParameter.cs
@@ -1,4 +1,4 @@
-﻿using AsmResolver.DotNet;
+using AsmResolver.DotNet;
 using AsmResolver.DotNet.Signatures.Types;
 
 namespace Cpp2IL.Core.Model.CustomAttributes;
@@ -12,5 +12,10 @@ public abstract class BaseCustomAttributeTypeParameter : BaseCustomAttributePara
     {
     }
 
+    /// <summary>
+    /// Convert the parameter to an AsmResolver <see cref="TypeSignature"/>.
+    /// </summary>
+    /// <param name="parentModule">The <see cref="ModuleDefinition"/> this signature is being imported into.</param>
+    /// <returns>An imported <see cref="TypeSignature"/> for the <paramref name="parentModule"/>.</returns>
     public abstract TypeSignature? ToTypeSignature(ModuleDefinition parentModule);
 }

--- a/Cpp2IL.Core/Utils/AsmResolver/AsmResolverUtils.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/AsmResolverUtils.cs
@@ -284,12 +284,10 @@ namespace Cpp2IL.Core.Utils.AsmResolver
             return ret;
         }
 
-        public static TypeSignature ImportTypeSignatureIfNeeded(this ReferenceImporter importer, TypeSignature signature) => signature is GenericParameterSignature ? signature : importer.ImportTypeSignature(signature);
-
         public static ITypeDefOrRef ImportTypeIfNeeded(this ReferenceImporter importer, ITypeDefOrRef type)
         {
             if (type is TypeSpecification spec)
-                return new TypeSpecification(importer.ImportTypeSignatureIfNeeded(spec.Signature!));
+                return new TypeSpecification(importer.ImportTypeSignature(spec.Signature!));
 
             return importer.ImportType(type);
         }

--- a/Cpp2IL.Core/Utils/AsmResolver/CilInstructionCollectionExtensions.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/CilInstructionCollectionExtensions.cs
@@ -1,5 +1,10 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using AsmResolver.DotNet.Code.Cil;
 using AsmResolver.DotNet.Signatures.Types;
+using AsmResolver.PE.DotNet.Cil;
+using AsmResolver.PE.DotNet.Metadata.Tables.Rows;
 
 namespace Cpp2IL.Core.Utils.AsmResolver;
 
@@ -10,5 +15,100 @@ internal static class CilInstructionCollectionExtensions
         var variable = new CilLocalVariable(variableType);
         instructions.Owner.LocalVariables.Add(variable);
         return variable;
+    }
+
+    public static void AddDefaultValueForType(this CilInstructionCollection instructions, TypeSignature type)
+    {
+        if (type is CorLibTypeSignature { IsValueType: true } corLibTypeSignature)
+        {
+            instructions.AddDefaultPrimitiveValue(corLibTypeSignature);
+        }
+        else if (type is ByReferenceTypeSignature)
+        {
+            instructions.AddNullRef();
+        }
+        else if (type.IsValueTypeOrGenericParameter())
+        {
+            instructions.AddDefaultValueForUnknownType(type);
+        }
+        else
+        {
+            instructions.Add(CilOpCodes.Ldnull);
+        }
+    }
+
+    /// <summary>
+    /// Load a null reference onto the stack.
+    /// </summary>
+    /// <remarks>
+    /// The specified instructions come from the documentation for <see cref="Unsafe.NullRef{T}"/>.<br/>
+    /// They decompile as: <code>ref *(T*)null</code>
+    /// The decompilation is valid C# and is the most optimized implementation.
+    /// However, it does produce a compiler warning.
+    /// </remarks>
+    /// <param name="instructions"></param>
+    private static void AddNullRef(this CilInstructionCollection instructions)
+    {
+        instructions.Add(CilOpCodes.Ldc_I4_0);
+        instructions.Add(CilOpCodes.Conv_U);
+    }
+
+    /// <summary>
+    /// Load the default value onto the stack for an unknown type.
+    /// </summary>
+    /// <remarks>
+    /// This is a silver bullet. It handles any type except void and by ref.
+    /// </remarks>
+    /// <param name="instructions"></param>
+    /// <param name="type"></param>
+    private static void AddDefaultValueForUnknownType(this CilInstructionCollection instructions, TypeSignature type)
+    {
+        Debug.Assert(type is not CorLibTypeSignature { ElementType: ElementType.Void } and not ByReferenceTypeSignature);
+        var variable = instructions.AddLocalVariable(type);
+        instructions.Add(CilOpCodes.Ldloca, variable);
+        instructions.Add(CilOpCodes.Initobj, type.ToTypeDefOrRef());
+        instructions.Add(CilOpCodes.Ldloc, variable);
+    }
+
+    private static void AddDefaultPrimitiveValue(this CilInstructionCollection instructions, CorLibTypeSignature type)
+    {
+        switch (type.ElementType)
+        {
+            case ElementType.Void:
+                break;
+            case ElementType.U1 or ElementType.U2 or ElementType.U4 or ElementType.I1 or ElementType.I2 or ElementType.I4 or ElementType.Boolean or ElementType.Char:
+                instructions.Add(CilOpCodes.Ldc_I4_0);
+                break;
+            case ElementType.I8:
+                instructions.Add(CilOpCodes.Ldc_I4_0);
+                instructions.Add(CilOpCodes.Conv_I8);
+                break;
+            case ElementType.U8:
+                instructions.Add(CilOpCodes.Ldc_I4_0);
+                instructions.Add(CilOpCodes.Conv_U8);
+                break;
+            case ElementType.I:
+                instructions.Add(CilOpCodes.Ldc_I4_0);
+                instructions.Add(CilOpCodes.Conv_I);
+                break;
+            case ElementType.U:
+                instructions.Add(CilOpCodes.Ldc_I4_0);
+                instructions.Add(CilOpCodes.Conv_U);
+                break;
+            case ElementType.R4:
+                instructions.Add(CilOpCodes.Ldc_R4, 0f);
+                break;
+            case ElementType.R8:
+                instructions.Add(CilOpCodes.Ldc_R8, 0d);
+                break;
+            case ElementType.Object or ElementType.String:
+                instructions.Add(CilOpCodes.Ldnull);
+                break;
+            case ElementType.TypedByRef:
+                instructions.AddDefaultValueForUnknownType(type);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(null);
+        }
     }
 }

--- a/Cpp2IL.Core/Utils/AsmResolver/TypeSignatureExtensions.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/TypeSignatureExtensions.cs
@@ -1,0 +1,11 @@
+﻿using AsmResolver.DotNet.Signatures.Types;
+
+namespace Cpp2IL.Core.Utils.AsmResolver;
+
+internal static class TypeSignatureExtensions
+{
+    public static bool IsValueTypeOrGenericParameter(this TypeSignature type)
+    {
+        return type is { IsValueType: true } or GenericParameterSignature;
+    }
+}


### PR DESCRIPTION
Resolves #198 

This pull request ensures that:

* The IL for generic types and methods is correct, especially out parameters.
* All uses of the `RefHelper` have been replaced with `ref *(T*)null`.
* Methods that return a `ref` now actually return a `ref`.
* Instructions for loading the default value of primitives have been special-cased to give neater decompilation.