### PR TITLE
look for plugins dir in application's base dir

### DIFF
--- a/Cpp2IL.Core/Cpp2IlApi.cs
+++ b/Cpp2IL.Core/Cpp2IlApi.cs
@@ -23,6 +23,7 @@ namespace Cpp2IL.Core
         public static void Init(string pluginsDir = "Plugins")
         {
             Cpp2IlPluginManager.LoadFromDirectory(Path.Combine(Environment.CurrentDirectory, pluginsDir));
+            Cpp2IlPluginManager.LoadFromDirectory(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, pluginsDir));
             Cpp2IlPluginManager.InitAll();
         }
 


### PR DESCRIPTION
Looking for the `Plugins` dir in the current working directory is kind of not expected behaviour but this can enable some customized usage. But again I think it should also look for `Plugins` directory in the base directory of the application..