### PR TITLE
Fixed wasm field offsets always returning -1 issue

### DIFF
--- a/LibCpp2IL/Il2CppBinary.cs
+++ b/LibCpp2IL/Il2CppBinary.cs
@@ -389,7 +389,7 @@ namespace LibCpp2IL
                     {
                         var offsetOffset = (ulong)MapVirtualAddressToRaw(ptr) + 4ul * (ulong)fieldIndexInType;
                         Position = (long)offsetOffset;
-                        offset = ReadInt32();
+                        offset = (int)ReadNInt();
                     }
                 }
                 else


### PR DESCRIPTION
Not tested with 64bit binaries, but should be fine as we always set the `BaseStream.Position` to the expected place, right?