### PR TITLE
Use Assetripper.Primitives

### DIFF
--- a/Cpp2IL.Core.Tests/GameLoader.cs
+++ b/Cpp2IL.Core.Tests/GameLoader.cs
@@ -1,4 +1,4 @@
-using AssetRipper.VersionUtilities;
+using AssetRipper.Primitives;
 using Cpp2IL.Core.Api;
 using Cpp2IL.Core.InstructionSets;
 using Cpp2IL.Core.Model.Contexts;

--- a/Cpp2IL.Core/Cpp2IlApi.cs
+++ b/Cpp2IL.Core/Cpp2IlApi.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using AssetRipper.VersionUtilities;
+using AssetRipper.Primitives;
 using Cpp2IL.Core.Exceptions;
 using Cpp2IL.Core.Logging;
 using Cpp2IL.Core.Model.Contexts;

--- a/Cpp2IL.Core/Cpp2IlRuntimeArgs.cs
+++ b/Cpp2IL.Core/Cpp2IlRuntimeArgs.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using AssetRipper.VersionUtilities;
+using AssetRipper.Primitives;
 using Cpp2IL.Core.Api;
 
 namespace Cpp2IL.Core

--- a/Cpp2IL.Gui/GuiUtils.cs
+++ b/Cpp2IL.Gui/GuiUtils.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using AsmResolver;
 using AsmResolver.PE;
 using AsmResolver.PE.Win32Resources;
-using AssetRipper.VersionUtilities;
+using AssetRipper.Primitives;
 using Cpp2IL.Core.Extensions;
 using LibCpp2IL;
 

--- a/Cpp2IL.Gui/Models/DroppedGame.cs
+++ b/Cpp2IL.Gui/Models/DroppedGame.cs
@@ -1,4 +1,4 @@
-using AssetRipper.VersionUtilities;
+using AssetRipper.Primitives;
 using Cpp2IL.Core.Extensions;
 using LibCpp2IL;
 

--- a/Cpp2IL.Gui/Models/DroppedSingleApkGame.cs
+++ b/Cpp2IL.Gui/Models/DroppedSingleApkGame.cs
@@ -2,7 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using AssetRipper.VersionUtilities;
+using AssetRipper.Primitives;
 using Cpp2IL.Core.Utils;
 using LibCpp2IL;
 using System.IO.Compression;

--- a/Cpp2IL.Gui/Models/DroppedWindowsGame.cs
+++ b/Cpp2IL.Gui/Models/DroppedWindowsGame.cs
@@ -2,7 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using AssetRipper.VersionUtilities;
+using AssetRipper.Primitives;
 using Cpp2IL.Core.Utils;
 using LibCpp2IL;
 

--- a/Cpp2IL.Gui/Models/LooseFilesDroppedGame.cs
+++ b/Cpp2IL.Gui/Models/LooseFilesDroppedGame.cs
@@ -1,6 +1,6 @@
 using System.IO;
 using System.Linq;
-using AssetRipper.VersionUtilities;
+using AssetRipper.Primitives;
 using LibCpp2IL;
 using LibCpp2IL.Metadata;
 

--- a/Cpp2IL.Gui/ViewModels/MainWindowViewModel.cs
+++ b/Cpp2IL.Gui/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading;
-using AssetRipper.VersionUtilities;
+using AssetRipper.Primitives;
 using Avalonia.Threading;
 using AvaloniaEdit.Document;
 using Cpp2IL.Core;

--- a/Cpp2IL/Program.cs
+++ b/Cpp2IL/Program.cs
@@ -15,7 +15,7 @@ using Cpp2IL.Core.Utils;
 using Cpp2IL.Core.Exceptions;
 #endif
 using LibCpp2IL.Wasm;
-using AssetRipper.VersionUtilities;
+using AssetRipper.Primitives;
 using Cpp2IL.Core.Extensions;
 using LibCpp2IL;
 

--- a/LibCpp2IL/LibCpp2IL.csproj
+++ b/LibCpp2IL/LibCpp2IL.csproj
@@ -22,7 +22,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AssetRipper.VersionUtilities" Version="1.3.1" />
+        <PackageReference Include="AssetRipper.Primitives" Version="2.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">

--- a/LibCpp2IL/LibCpp2IlMain.cs
+++ b/LibCpp2IL/LibCpp2IlMain.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using AssetRipper.VersionUtilities;
+using AssetRipper.Primitives;
 using LibCpp2IL.Elf;
 using LibCpp2IL.Logging;
 using LibCpp2IL.Metadata;

--- a/LibCpp2IL/Metadata/Il2CppMetadata.cs
+++ b/LibCpp2IL/Metadata/Il2CppMetadata.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using AssetRipper.VersionUtilities;
+using AssetRipper.Primitives;
 using LibCpp2IL.BinaryStructures;
 using LibCpp2IL.Logging;
 

--- a/LibCpp2ILTests/Tests.cs
+++ b/LibCpp2ILTests/Tests.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using System.Net.Http;
-using AssetRipper.VersionUtilities;
+using AssetRipper.Primitives;
 using LibCpp2IL;
 using Xunit;
 using Xunit.Abstractions;


### PR DESCRIPTION
The AssetRipper.VersionUtilities package has been depreciated and replaced with AssetRipper.Primitives.