### PR TITLE
ELF: Properly handle address outside of file-backed regions

### DIFF
--- a/LibCpp2IL/Elf/ElfFile.cs
+++ b/LibCpp2IL/Elf/ElfFile.cs
@@ -691,6 +691,13 @@ namespace LibCpp2IL.Elf
                     throw new InvalidOperationException($"No entry in the Elf PHT contains virtual address 0x{addr:X}");
                 else
                     return VirtToRawInvalidNoMatch;
+            
+            if (addr >= section.VirtualAddress + section.RawSize)
+                if (throwOnError)
+                    throw new InvalidOperationException(
+                        $"Virtual address {section.VirtualAddress:X} is located outside of the file-backed portion of Elf PHT section at 0x{section.VirtualAddress:X}");
+                else
+                    return VirtToRawInvalidOutOfBounds;
 
             return (long) (addr - (section.VirtualAddress - section.RawAddress));
         }


### PR DESCRIPTION
Currently, only cases where the virtual address is located outside of any ELF PHT entry are handled. However, since a PHT entry can also only be partially backed by file contents, this causes normally invalid address translations to succeed, which in turn leads to weird issues later on.

I've personally seen this cause issues with retrieving method pointers from Unity.Purchasing.AppleCore.dll on Android, where methodPointers points into .bss, but Cpp2IL still tries to read them from the file due to the entry containing the section being partially file-backed.