### PR TITLE
Make call analysis compatible with native method detection

### DIFF
--- a/Cpp2IL.Core/Model/Contexts/ApplicationAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/ApplicationAnalysisContext.cs
@@ -153,7 +153,7 @@ public class ApplicationAnalysisContext : ContextWithDataStorage
         return AssembliesByName[name];
     }
 
-    public TypeAnalysisContext? ResolveContextForType(Il2CppTypeDefinition typeDefinition) => GetAssemblyByName(typeDefinition.DeclaringAssembly!.Name!)?.TypesByDefinition[typeDefinition];
+    public TypeAnalysisContext? ResolveContextForType(Il2CppTypeDefinition typeDefinition) => GetAssemblyByName(typeDefinition.DeclaringAssembly!.Name!)?.GetTypeByDefinition(typeDefinition);
 
     public BaseKeyFunctionAddresses GetOrCreateKeyFunctionAddresses()
     {

--- a/Cpp2IL.Core/Model/Contexts/AssemblyAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/AssemblyAnalysisContext.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Cpp2IL.Core.Extensions;
 using Cpp2IL.Core.Utils;
 using LibCpp2IL.BinaryStructures;
@@ -40,9 +41,9 @@ public class AssemblyAnalysisContext : HasCustomAttributes
 
     public override string CustomAttributeOwnerName => Definition.AssemblyName.Name; 
 
-    private Dictionary<string, TypeAnalysisContext> TypesByName = new();
+    private readonly Dictionary<string, TypeAnalysisContext> TypesByName = new();
     
-    public readonly Dictionary<Il2CppTypeDefinition, TypeAnalysisContext> TypesByDefinition = new();
+    private readonly Dictionary<Il2CppTypeDefinition, TypeAnalysisContext> TypesByDefinition = new();
     
     /// <summary>
     /// Get assembly name without the extension and with any invalid path characters or elements removed.
@@ -77,14 +78,16 @@ public class AssemblyAnalysisContext : HasCustomAttributes
         }
     }
 
-    public TypeAnalysisContext InjectType(string ns, string name, TypeAnalysisContext? baseType)
+    public TypeAnalysisContext InjectType(string ns, string name, TypeAnalysisContext? baseType, TypeAttributes typeAttributes = TypeAnalysisContext.DefaultTypeAttributes)
     {
-        var ret = new InjectedTypeAnalysisContext(this, name, ns, baseType);
+        var ret = new InjectedTypeAnalysisContext(this, name, ns, baseType, typeAttributes);
         Types.Add(ret);
         return ret;
     }
 
     public TypeAnalysisContext? GetTypeByFullName(string fullName) => TypesByName.TryGetValue(fullName, out var typeContext) ? typeContext : null;
-    
+
+    public TypeAnalysisContext? GetTypeByDefinition(Il2CppTypeDefinition typeDefinition) => TypesByDefinition.TryGetValue(typeDefinition, out var typeContext) ? typeContext : null;
+
     public override string ToString() => "Assembly: " + Definition.AssemblyName.Name;
 }

--- a/Cpp2IL.Core/Model/Contexts/InjectedTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/InjectedTypeAnalysisContext.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Reflection;
 
 namespace Cpp2IL.Core.Model.Contexts;
@@ -9,11 +9,14 @@ public class InjectedTypeAnalysisContext : TypeAnalysisContext
 
     public override string DefaultNs { get; }
 
-    public InjectedTypeAnalysisContext(AssemblyAnalysisContext containingAssembly, string name, string ns, TypeAnalysisContext? baseType) : base(null, containingAssembly)
+    public override TypeAttributes TypeAttributes { get; }
+
+    public InjectedTypeAnalysisContext(AssemblyAnalysisContext containingAssembly, string name, string ns, TypeAnalysisContext? baseType, TypeAttributes typeAttributes = DefaultTypeAttributes) : base(null, containingAssembly)
     {
         DefaultName = name;
         DefaultNs = ns;
         OverrideBaseType = baseType;
+        TypeAttributes = typeAttributes;
     }
 
     public InjectedMethodAnalysisContext InjectMethodContext(string methodName, bool isStatic, TypeAnalysisContext returnType, MethodAttributes attributes, params TypeAnalysisContext[] args)

--- a/Cpp2IL.Core/Model/Contexts/ReferencedTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/ReferencedTypeAnalysisContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using LibCpp2IL.BinaryStructures;
@@ -34,6 +34,10 @@ public abstract class ReferencedTypeAnalysisContext : TypeAnalysisContext
     };
 
     protected override int CustomAttributeIndex => -1;
+
+    public sealed override bool IsGenericInstance => GenericArguments.Count > 0;
+
+    public sealed override int GenericParameterCount => GenericArguments.Count;
 
     public override AssemblyAnalysisContext CustomAttributeAssembly => DeclaringAssembly;
 

--- a/Cpp2IL.Core/Model/Contexts/TypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/TypeAnalysisContext.cs
@@ -18,6 +18,8 @@ namespace Cpp2IL.Core.Model.Contexts;
 /// </summary>
 public class TypeAnalysisContext : HasCustomAttributesAndName, ITypeInfoProvider, ICSharpSourceToken
 {
+    internal const TypeAttributes DefaultTypeAttributes = TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed;
+
     /// <summary>
     /// The context for the assembly this type was defined in.
     /// </summary>
@@ -203,15 +205,15 @@ public class TypeAnalysisContext : HasCustomAttributesAndName, ITypeInfoProvider
     }
 
     public IEnumerable<ITypeInfoProvider> Interfaces => Definition!.RawInterfaces!.Select(t => GetSndnProviderForType(AppContext, t));
-    public TypeAttributes TypeAttributes => Definition!.Attributes;
-    public int GenericParameterCount => Definition!.GenericContainer?.genericParameterCount ?? 0;
+    public virtual TypeAttributes TypeAttributes => Definition?.Attributes ?? DefaultTypeAttributes;
+    public virtual int GenericParameterCount => Definition!.GenericContainer?.genericParameterCount ?? 0;
     public string OriginalTypeName => DefaultName;
     public string RewrittenTypeName => Name;
     public string TypeNamespace => Namespace;
-    public bool IsGenericInstance => false;
-    public bool IsValueType => Definition!.IsValueType;
-    public bool IsEnumType => Definition!.IsEnumType;
-    public bool IsInterface => Definition!.IsInterface;
+    public virtual bool IsGenericInstance => false;
+    public bool IsValueType => Definition?.IsValueType ?? BaseType is { Namespace: "System", Name: "ValueType" };
+    public bool IsEnumType => Definition?.IsEnumType ?? BaseType is { Namespace: "System", Name: "Enum" };
+    public bool IsInterface => Definition?.IsInterface ?? ((TypeAttributes & TypeAttributes.Interface) != default);
     public IEnumerable<ITypeInfoProvider> GenericArgumentInfoProviders => Array.Empty<ITypeInfoProvider>();
     public IEnumerable<IFieldInfoProvider> FieldInfoProviders => Fields;
     public IEnumerable<IMethodInfoProvider> MethodInfoProviders => Methods;

--- a/Cpp2IL.Core/OutputFormats/AsmResolverDummyDllOutputFormat.cs
+++ b/Cpp2IL.Core/OutputFormats/AsmResolverDummyDllOutputFormat.cs
@@ -204,10 +204,8 @@ public class AsmResolverDummyDllOutputFormat : Cpp2IlOutputFormat
     {
         var typeDef = typeContext.Definition;
 
-        const int defaultAttributes = (int)(TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed);
-
         //Initialize an empty type definition
-        var ret = new TypeDefinition(typeContext.Namespace, typeContext.Name, (TypeAttributes)(typeDef?.Flags ?? defaultAttributes));
+        var ret = new TypeDefinition(typeContext.Namespace, typeContext.Name, (TypeAttributes)typeContext.TypeAttributes);
 
         //Set up its layout
         if (typeDef != null && typeDef.BaseType?.ToString() != "System.Enum")

--- a/Cpp2IL.Core/ProcessingLayers/NativeMethodDetectionProcessingLayer.cs
+++ b/Cpp2IL.Core/ProcessingLayers/NativeMethodDetectionProcessingLayer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Cpp2IL.Core.Api;
 using Cpp2IL.Core.ISIL;
 using Cpp2IL.Core.Model.Contexts;
@@ -16,7 +17,11 @@ public class NativeMethodDetectionProcessingLayer : Cpp2IlProcessingLayer
     public override void Process(ApplicationAnalysisContext appContext, Action<int, int>? progressCallback = null)
     {
         var nativeMethodInfoStack = new Stack<(ulong, bool)>();
-        var cppNativeMethodsType = appContext.AssembliesByName["mscorlib"].InjectType("Cpp2ILInjected", "CppNativeMethods", null);
+        var cppNativeMethodsType = appContext.AssembliesByName["mscorlib"].InjectType(
+            "Cpp2ILInjected",
+            "CppNativeMethods",
+            null,
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);//public static class
         foreach (var assemblyAnalysisContext in appContext.Assemblies)
         {
             foreach (var m in assemblyAnalysisContext.Types.SelectMany(t => t.Methods))


### PR DESCRIPTION
* Call analysis can be used with native method detection
* Native method detection generates a static class
* Injected classes can override their TypeAttributes