### PR TITLE
Fix iOS file loading and account for if the next function is not mappable to a raw address in the binary

### DIFF
--- a/Cpp2IL.Core/Utils/MiscUtils.cs
+++ b/Cpp2IL.Core/Utils/MiscUtils.cs
@@ -222,6 +222,9 @@ namespace Cpp2IL.Core.Utils
             if (ret <= current && upper == _allKnownFunctionStarts.Count - 1)
                 return 0;
 
+            if (!LibCpp2IlMain.Binary!.TryMapVirtualAddressToRaw(ret, out _))
+                return 0;
+
             return ret;
         }
 

--- a/LibCpp2IL/MachO/MachOFile.cs
+++ b/LibCpp2IL/MachO/MachOFile.cs
@@ -76,8 +76,23 @@ namespace LibCpp2IL.MachO
             
             var dyldData = _loadCommands.FirstOrDefault(c => c.Command is LoadCommandId.LC_DYLD_INFO or LoadCommandId.LC_DYLD_INFO_ONLY)?.CommandData as MachODynamicLinkerCommand;
             var exports = dyldData?.Exports ?? Array.Empty<MachOExportEntry>();
+            // DEBUG
+            // var debugDict = new Dictionary<long, string>();
+            // for (int index = 0; index < exports.Length; ++index) {
+            //     var export = exports[index];
+            //     Console.WriteLine($"Export: {export.Name[1..]} -> 0x{export.Address:X}");
+            //     // detect duplicate
+            //     if (debugDict.ContainsKey(export.Address) && debugDict[export.Address] != export.Name[1..]) {
+            //         Console.WriteLine($"Duplicate: {export.Name[1..]} -> 0x{export.Address:X}");
+            //     }
+            //     debugDict[export.Address] = export.Name[1..];
+            // }
             _exportAddressesDict = exports.ToDictionary(e => e.Name[1..], e => e.Address); //Skip the first character, which is a leading underscore inserted by the compiler
-            _exportNamesDict = _exportAddressesDict.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+            _exportNamesDict = new Dictionary<long, string>();
+            foreach (var export in exports) // there may be duplicate names
+            {
+                _exportNamesDict[export.Address] = export.Name[1..];
+            }
             
             LibLogger.VerboseNewline($"Found {_exportAddressesDict.Count} exports in the DYLD info load command.");
             


### PR DESCRIPTION
Firstly, There can be duplicate symbols for the same address, which messes up the ToDictionary method. I just switched that specific call to a different one so that it doesn't error because of that again.

Secondly, some methods (for example the UnityEngine.Purchasing.INativeAppleStore::get_appReceiptModification in UnityEngine.Purchasing.AppleCore.dll) return weird values for their next value, which in that case, it's better to treat it as an unmanaged function.