### PR TITLE
Handle strings in Call Analysis and Native Method Detection

### DIFF
--- a/Cpp2IL.Core/ProcessingLayers/CallAnalysisProcessingLayer.cs
+++ b/Cpp2IL.Core/ProcessingLayers/CallAnalysisProcessingLayer.cs
@@ -96,7 +96,7 @@ public class CallAnalysisProcessingLayer : Cpp2IlProcessingLayer
                     {
                         continue;
                     }
-                    if (instruction.Operands.Length > 0 && instruction.Operands[0].Data is IsilImmediateOperand operand)
+                    if (instruction.Operands.Length > 0 && instruction.Operands[0].Data is IsilImmediateOperand operand && operand.Value is not string)
                     {
                         var address = operand.Value.ToUInt64(null);
                         if (appContext.MethodsByAddress.TryGetValue(address, out var list))

--- a/Cpp2IL.Core/ProcessingLayers/NativeMethodDetectionProcessingLayer.cs
+++ b/Cpp2IL.Core/ProcessingLayers/NativeMethodDetectionProcessingLayer.cs
@@ -86,7 +86,7 @@ public class NativeMethodDetectionProcessingLayer : Cpp2IlProcessingLayer
 
     private static bool TryGetAddressFromInstruction(InstructionSetIndependentInstruction instruction, out ulong address)
     {
-        if (instruction.Operands.Length > 0 && instruction.Operands[0].Data is IsilImmediateOperand operand)
+        if (instruction.Operands.Length > 0 && instruction.Operands[0].Data is IsilImmediateOperand operand && operand.Value is not string)
         {
             address = operand.Value.ToUInt64(null);
             return true;


### PR DESCRIPTION
ToUInt64 is throwing.