### PR TITLE
LibCpp2IL: Return empty array if number of read elements is 0

### DIFF
--- a/LibCpp2IL/Metadata/Il2CppMetadata.cs
+++ b/LibCpp2IL/Metadata/Il2CppMetadata.cs
@@ -314,6 +314,10 @@ public class Il2CppMetadata : ClassReadingBinaryReader
             //Now we can work out how many elements there are.
             var numElements = length / elementSize;
 
+            if (numElements == 0) {
+                return [];
+            }
+
             //And so we can allocate an array of that length, and assign the first element.
             var arr = new T[numElements];
             arr[0] = first;


### PR DESCRIPTION
If length is 0, indexing array at 1 is an exception https://github.com/SamboyCoding/Cpp2IL/blob/2f8e5b3fcbdefaf4b851d4234ede44f6c4138efa/LibCpp2IL/Metadata/Il2CppMetadata.cs#L322

Fixes https://github.com/SamboyCoding/Cpp2IL/issues/342