### PR TITLE
Stripped Code Registration Fix

### DIFF
--- a/Cpp2IL.Plugin.StrippedCodeRegSupport/StrippedCodeRegSupportPlugin.cs
+++ b/Cpp2IL.Plugin.StrippedCodeRegSupport/StrippedCodeRegSupportPlugin.cs
@@ -104,7 +104,6 @@ public class StrippedCodeRegSupportPlugin : Cpp2IlPlugin
         while (binary.ReadNUint() != 0)
         {
             endOfCodegenModulesList += pointerSize;
-            binary.Position += (long)pointerSize;
         }
 
         //We're at the end, so walk one back to get the last valid pointer.


### PR DESCRIPTION
The binary position was getting incremented twice, which jumped over the null pointer that would indicate the end.

Resolves #380 