### PR TITLE
Set AssemblyDefinition::PublicKey when generating AsmResolver assemblies

### DIFF
--- a/Cpp2IL.Core/OutputFormats/AsmResolverDummyDllOutputFormat.cs
+++ b/Cpp2IL.Core/OutputFormats/AsmResolverDummyDllOutputFormat.cs
@@ -179,8 +179,10 @@ public abstract class AsmResolverDllOutputFormat : Cpp2IlOutputFormat
 
         var ourAssembly = new AssemblyDefinition(assemblyNameString, version)
         {
-            HashAlgorithm = (AssemblyHashAlgorithm)assemblyDefinition.AssemblyName.hash_alg, Attributes = (AssemblyAttributes)assemblyDefinition.AssemblyName.flags, Culture = assemblyDefinition.AssemblyName.Culture,
-            //TODO find a way to set hash? or not needed
+            HashAlgorithm = (AssemblyHashAlgorithm)assemblyDefinition.AssemblyName.hash_alg,
+            Attributes = (AssemblyAttributes)assemblyDefinition.AssemblyName.flags,
+            Culture = assemblyDefinition.AssemblyName.Culture,
+            PublicKey = assemblyDefinition.AssemblyName.PublicKey,
         };
 
         //Setting the corlib module allows element types in references to that assembly to be set correctly without us having to manually set them.

--- a/LibCpp2IL/ClassReadingBinaryReader.cs
+++ b/LibCpp2IL/ClassReadingBinaryReader.cs
@@ -302,7 +302,8 @@ public class ClassReadingBinaryReader : EndianAwareBinaryReader
         if (offset != -1)
             Position = offset;
 
-        var initialPos = Position;
+        if (count == 0)
+            return [];
 
         try
         {

--- a/LibCpp2IL/Metadata/Il2CppAssemblyNameDefinition.cs
+++ b/LibCpp2IL/Metadata/Il2CppAssemblyNameDefinition.cs
@@ -28,7 +28,7 @@ public class Il2CppAssemblyNameDefinition : ReadableClass
     {
         get
         {
-            var result = LibCpp2IlMain.TheMetadata!.GetBytesFromIndex(publicKeyIndex);
+            var result = LibCpp2IlMain.TheMetadata!.GetByteArrayFromIndex(publicKeyIndex);
             return result.Length == 0 ? null : result;
         }
     }

--- a/LibCpp2IL/Metadata/Il2CppAssemblyNameDefinition.cs
+++ b/LibCpp2IL/Metadata/Il2CppAssemblyNameDefinition.cs
@@ -24,7 +24,28 @@ public class Il2CppAssemblyNameDefinition : ReadableClass
     public string Name => LibCpp2IlMain.TheMetadata!.GetStringFromIndex(nameIndex);
     public string Culture => LibCpp2IlMain.TheMetadata!.GetStringFromIndex(cultureIndex);
 
-    public string PublicKey => LibCpp2IlMain.TheMetadata!.GetStringFromIndex(publicKeyIndex);
+    public byte[]? PublicKey
+    {
+        get
+        {
+            var result = LibCpp2IlMain.TheMetadata!.GetBytesFromIndex(publicKeyIndex);
+            return result.Length == 0 ? null : result;
+        }
+    }
+
+    /// <summary>
+    /// This returns the public key token as a byte array, or null if the token is 0.
+    /// </summary>
+    /// <remarks>
+    /// Returning null is necessary to match the behavior of AsmResolver.
+    /// </remarks>
+    public byte[]? PublicKeyToken
+    {
+        get
+        {
+            return publicKeyToken == default ? null : BitConverter.GetBytes(publicKeyToken);
+        }
+    }
 
     public string HashValue => LibCpp2IlMain.MetadataVersion > 24.3f ? "NULL" : LibCpp2IlMain.TheMetadata!.GetStringFromIndex(hashValueIndex);
 

--- a/LibCpp2IL/Metadata/Il2CppMetadata.cs
+++ b/LibCpp2IL/Metadata/Il2CppMetadata.cs
@@ -426,6 +426,18 @@ public class Il2CppMetadata : ClassReadingBinaryReader
         }
     }
 
+    /// <summary>
+    /// Read a byte array from the string data section of the metadata.
+    /// </summary>
+    /// <param name="index">The offset relative to the start of the string section.</param>
+    /// <returns>The </returns>
+    public byte[] GetBytesFromIndex(int index)
+    {
+        var offset = metadataHeader.stringOffset + index;
+        var count = ReadUnityCompressedUIntAtRawAddr(offset, out var bytesRead);
+        return ReadByteArrayAtRawAddress(offset + bytesRead, (int)count);
+    }
+
     internal string ReadStringFromIndexNoReadLock(int index)
     {
         if (!_cachedStrings.ContainsKey(index))

--- a/LibCpp2IL/Metadata/Il2CppMetadata.cs
+++ b/LibCpp2IL/Metadata/Il2CppMetadata.cs
@@ -413,6 +413,18 @@ public class Il2CppMetadata : ClassReadingBinaryReader
 
     private ConcurrentDictionary<int, string> _cachedStrings = new ConcurrentDictionary<int, string>();
 
+    /// <summary>
+    /// Read a byte array from the string data section of the metadata.
+    /// </summary>
+    /// <param name="index">The offset relative to the start of the string section.</param>
+    /// <returns>The </returns>
+    public byte[] GetByteArrayFromIndex(int index)
+    {
+        var offset = metadataHeader.stringOffset + index;
+        var count = ReadUnityCompressedUIntAtRawAddr(offset, out var bytesRead);
+        return ReadByteArrayAtRawAddress(offset + bytesRead, (int)count);
+    }
+
     public string GetStringFromIndex(int index)
     {
         GetLockOrThrow();
@@ -424,18 +436,6 @@ public class Il2CppMetadata : ClassReadingBinaryReader
         {
             ReleaseLock();
         }
-    }
-
-    /// <summary>
-    /// Read a byte array from the string data section of the metadata.
-    /// </summary>
-    /// <param name="index">The offset relative to the start of the string section.</param>
-    /// <returns>The </returns>
-    public byte[] GetBytesFromIndex(int index)
-    {
-        var offset = metadataHeader.stringOffset + index;
-        var count = ReadUnityCompressedUIntAtRawAddr(offset, out var bytesRead);
-        return ReadByteArrayAtRawAddress(offset + bytesRead, (int)count);
     }
 
     internal string ReadStringFromIndexNoReadLock(int index)

--- a/LibCpp2IL/Metadata/Il2CppMetadata.cs
+++ b/LibCpp2IL/Metadata/Il2CppMetadata.cs
@@ -411,8 +411,6 @@ public class Il2CppMetadata : ClassReadingBinaryReader
         return metadataHeader.fieldAndParameterDefaultValueDataOffset + index;
     }
 
-    private ConcurrentDictionary<int, string> _cachedStrings = new ConcurrentDictionary<int, string>();
-
     /// <summary>
     /// Read a byte array from the string data section of the metadata.
     /// </summary>
@@ -424,6 +422,8 @@ public class Il2CppMetadata : ClassReadingBinaryReader
         var count = ReadUnityCompressedUIntAtRawAddr(offset, out var bytesRead);
         return ReadByteArrayAtRawAddress(offset + bytesRead, (int)count);
     }
+
+    private ConcurrentDictionary<int, string> _cachedStrings = new ConcurrentDictionary<int, string>();
 
     public string GetStringFromIndex(int index)
     {


### PR DESCRIPTION
Not setting the `PublicKey` was causing `AsmResolver.DotNet.Signatures.SignatureComparer` to return false when comparing Mono methods and their corresponding Il2Cpp methods.