### PR TITLE
Ensure emitted method signatures have the correct generic parameter count

### DIFF
--- a/Cpp2IL.Core/Model/Contexts/MethodAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/MethodAnalysisContext.cs
@@ -78,6 +78,8 @@ public class MethodAnalysisContext : HasCustomAttributesAndName, IMethodInfoProv
 
     public int ParameterCount => Parameters.Count;
 
+    public int GenericParameterCount => Definition?.GenericContainer?.genericParameterCount ?? 0;
+
     //TODO Support custom attributes on return types (v31 feature)
     public TypeAnalysisContext ReturnTypeContext => InjectedReturnType ?? DeclaringType!.DeclaringAssembly.ResolveIl2CppType(Definition!.RawReturnType!);
     

--- a/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
@@ -401,7 +401,9 @@ public static class AsmResolverAssemblyPopulator
             }
 
 
-            var signature = methodCtx.IsStatic ? MethodSignature.CreateStatic(returnType, parameterTypes) : MethodSignature.CreateInstance(returnType, parameterTypes);
+            var signature = methodCtx.IsStatic
+                ? MethodSignature.CreateStatic(returnType, methodCtx.GenericParameterCount, parameterTypes)
+                : MethodSignature.CreateInstance(returnType, methodCtx.GenericParameterCount, parameterTypes);
 
             var managedMethod = new MethodDefinition(methodCtx.Name, (MethodAttributes)methodCtx.Attributes, signature);
 

--- a/Cpp2IL.Core/Utils/AsmResolver/ContextToMethodDescriptor.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/ContextToMethodDescriptor.cs
@@ -17,11 +17,9 @@ public static class ContextToMethodDescriptor
         var returnType = context.ReturnTypeContext.ToTypeSignature(parentModule);
         var parameters = context.Parameters.Select(p => p.ToTypeSignature(parentModule));
 
-        var genericParameterCount = context.Definition?.GenericContainer?.genericParameterCount ?? 0;
-
         return context.IsStatic
-            ? MethodSignature.CreateStatic(returnType, genericParameterCount, parameters)
-            : MethodSignature.CreateInstance(returnType, genericParameterCount, parameters);
+            ? MethodSignature.CreateStatic(returnType, context.GenericParameterCount, parameters)
+            : MethodSignature.CreateInstance(returnType, context.GenericParameterCount, parameters);
     }
 
     public static IMethodDescriptor ToMethodDescriptor(this MethodAnalysisContext context, ModuleDefinition parentModule)


### PR DESCRIPTION
Previously, all method signatures were emitted as non-generic.