### PR TITLE
Program: Resolve ~ as user home

### DIFF
--- a/Cpp2IL/Program.cs
+++ b/Cpp2IL/Program.cs
@@ -522,7 +522,9 @@ internal class Program
 
         if (options.ForcedBinaryPath == null)
         {
-            ResolvePathsFromCommandLine(options.GamePath.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)), options.ExeName, ref result);
+            if (options.GamePath.StartsWith("~"))
+                options.GamePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + options.GamePath.Substring(1);
+            ResolvePathsFromCommandLine(options.GamePath, options.ExeName, ref result);
         }
         else
         {
@@ -534,7 +536,7 @@ internal class Program
             if (result.UnityVersion.Type == UnityVersionType.Alpha && result.UnityVersion.Build == 0)
                 //Map a0 to f1 - we assume the user simply didn't provide the final part of the version number
                 result.UnityVersion = new UnityVersion(result.UnityVersion.Major, result.UnityVersion.Minor, result.UnityVersion.Build, UnityVersionType.Final, 1);
-            
+
             result.Valid = true;
         }
 

--- a/Cpp2IL/Program.cs
+++ b/Cpp2IL/Program.cs
@@ -522,7 +522,7 @@ internal class Program
 
         if (options.ForcedBinaryPath == null)
         {
-            ResolvePathsFromCommandLine(options.GamePath, options.ExeName, ref result);
+            ResolvePathsFromCommandLine(options.GamePath.Replace("~", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)), options.ExeName, ref result);
         }
         else
         {


### PR DESCRIPTION
C# treats `~` as directory in cwd, so you have to pass absolute path instead (like `/home/user`)

Test: `./bin/Release/net9.0/linux-x64/Cpp2IL --game-path=~/Downloads/merged.apk`
Result: `[Fail] [Program] Execution Failed: Could not find a valid unity game at /home/commonuserlol/projects/Cpp2IL/Cpp2IL/~/Downloads/merged.apk`

Result after fix: `[Warn] [Program] No output format requested, so not outputting anything. The il2cpp game loaded properly though!`

Credit: https://stackoverflow.com/questions/4796254/relative-path-to-absolute-path-in-c