### PR TITLE
fix bugs the MetadataVersion in the WasmMemoryBlock file is incorrect

### DIFF
--- a/LibCpp2IL/Wasm/WasmMemoryBlock.cs
+++ b/LibCpp2IL/Wasm/WasmMemoryBlock.cs
@@ -34,7 +34,7 @@ public class WasmMemoryBlock : ClassReadingBinaryReader
 
     public WasmMemoryBlock(WasmFile file) : base(BuildStream(file))
     {
-        MetadataVersion = file.MetadataVersion;
+        MetadataVersion = file.MetadataVersion <= 0 ? LibCpp2IlMain.MetadataVersion : file.MetadataVersion;
         is32Bit = true;
         Bytes = ((MemoryStream)BaseStream).ToArray();
     }


### PR DESCRIPTION
The MetadataVersion in WasmMemoryBlock is incorrectly set to 0 because the file.MetadataVersion always returns 0.
