### PR TITLE
Fix explicit interface method overrides

### DIFF
--- a/Cpp2IL.Core/Cpp2IL.Core.csproj
+++ b/Cpp2IL.Core/Cpp2IL.Core.csproj
@@ -40,8 +40,8 @@
 
     <ItemGroup>
         <!--Needed for DLL output-->
-        <PackageReference Include="AsmResolver.DotNet" Version="6.0.0-beta.1" />
-        <PackageReference Include="AssetRipper.CIL" Version="1.1.2" />
+        <PackageReference Include="AsmResolver.DotNet" Version="6.0.0-beta.2" />
+        <PackageReference Include="AssetRipper.CIL" Version="1.1.5" />
         
         <!--For ARM64 dissassembly-->
         <PackageReference Include="Disarm" Version="2022.1.0-master.57" />

--- a/Cpp2IL.Core/Model/Contexts/GenericInstanceTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/GenericInstanceTypeAnalysisContext.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using Cpp2IL.Core.Utils;
 using LibCpp2IL.BinaryStructures;
@@ -11,6 +12,8 @@ public class GenericInstanceTypeAnalysisContext : ReferencedTypeAnalysisContext
     public TypeAnalysisContext GenericType { get; }
 
     public List<TypeAnalysisContext> GenericArguments { get; } = [];
+
+    public override TypeAttributes TypeAttributes => GenericType.TypeAttributes;
 
     public override string DefaultName => $"{GenericType.Name}<{string.Join(", ", GenericArguments.Select(a => a.Name))}>";
 

--- a/Cpp2IL.Core/Model/Contexts/TypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/TypeAnalysisContext.cs
@@ -203,6 +203,11 @@ public class TypeAnalysisContext : HasCustomAttributesAndName, ITypeInfoProvider
         return new(this, DeclaringAssembly);
     }
 
+    public GenericInstanceTypeAnalysisContext MakeGenericInstanceType(IEnumerable<TypeAnalysisContext> genericArguments)
+    {
+        return new(this, genericArguments, DeclaringAssembly);
+    }
+
     public PointerTypeAnalysisContext MakePointerType()
     {
         return new(this, DeclaringAssembly);

--- a/Cpp2IL.Core/OutputFormats/AsmResolverDummyDllOutputFormat.cs
+++ b/Cpp2IL.Core/OutputFormats/AsmResolverDummyDllOutputFormat.cs
@@ -92,7 +92,7 @@ public abstract class AsmResolverDllOutputFormat : Cpp2IlOutputFormat
 #endif
 
         MiscUtils.ExecuteParallel(context.Assemblies, AsmResolverAssemblyPopulator.CopyDataFromIl2CppToManaged);
-        MiscUtils.ExecuteParallel(context.Assemblies, AsmResolverAssemblyPopulator.InferExplicitInterfaceImplementations);
+        MiscUtils.ExecuteParallel(context.Assemblies, AsmResolverAssemblyPopulator.AddExplicitInterfaceImplementations);
         MiscUtils.ExecuteParallel(context.Assemblies, FillMethodBodies);
 
         Logger.VerboseNewline($"{(DateTime.Now - start).TotalMilliseconds:F1}ms", "DllOutput");

--- a/Cpp2IL.Core/ProcessingLayers/CallAnalysisProcessingLayer.cs
+++ b/Cpp2IL.Core/ProcessingLayers/CallAnalysisProcessingLayer.cs
@@ -198,20 +198,20 @@ public class CallAnalysisProcessingLayer : Cpp2IlProcessingLayer
         (FieldAnalysisContext, object)? typeParametersField;
         if (targetMethod is ConcreteGenericMethodAnalysisContext concreteMethod)
         {
-            if (concreteMethod.MethodRef.MethodGenericParams.Length > 0)
+            if (concreteMethod.MethodGenericParameters.Length > 0)
             {
-                var parameters = new object?[concreteMethod.MethodRef.MethodGenericParams.Length];
+                var parameters = new object?[concreteMethod.MethodGenericParameters.Length];
 
                 for (var i = 0; i < parameters.Length; i++)
                 {
-                    var parameterType = concreteMethod.MethodRef.MethodGenericParams[i].ToContext(concreteMethod.DeclaringType!.DeclaringAssembly, i);
-                    if (parameterType is not null && parameterType.IsAccessibleTo(annotatedMethod.DeclaringType!))
+                    var parameterType = concreteMethod.MethodGenericParameters[i];
+                    if (parameterType.IsAccessibleTo(annotatedMethod.DeclaringType!))
                     {
                         parameters[i] = parameterType;
                     }
                     else
                     {
-                        parameters[i] = parameterType?.FullName;
+                        parameters[i] = parameterType.FullName;
                     }
                 }
 

--- a/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
@@ -374,8 +374,7 @@ public static class AsmResolverAssemblyPopulator
         {
             var methodDef = methodCtx.Definition;
 
-            var rawReturnType = methodDef != null ? methodDef.RawReturnType! : LibCpp2IlReflection.GetTypeFromDefinition(methodCtx.InjectedReturnType!.Definition ?? throw new("Injected methods with injected return types not supported at the moment."))!;
-            var returnType = importer.ImportTypeSignature(AsmResolverUtils.GetTypeSignatureFromIl2CppType(importer.TargetModule, rawReturnType));
+            var returnType = importer.ImportTypeSignature(methodCtx.ReturnTypeContext.ToTypeSignature(importer.TargetModule));
 
             var paramData = methodCtx.Parameters;
             var parameterTypes = new TypeSignature[paramData.Count];
@@ -529,7 +528,7 @@ public static class AsmResolverAssemblyPopulator
         }
     }
 
-    public static void InferExplicitInterfaceImplementations(AssemblyAnalysisContext asmContext)
+    public static void AddExplicitInterfaceImplementations(AssemblyAnalysisContext asmContext)
     {
         var managedAssembly = asmContext.GetExtraData<AssemblyDefinition>("AsmResolverAssembly") ?? throw new("AsmResolver assembly not found in assembly analysis context for " + asmContext);
 
@@ -546,7 +545,7 @@ public static class AsmResolverAssemblyPopulator
             try
 #endif
             {
-                InferExplicitInterfaceImplementations(managedType, importer);
+                AddExplicitInterfaceImplementations(managedType, typeContext, importer);
             }
 #if !DEBUG
             catch (Exception e)
@@ -557,71 +556,21 @@ public static class AsmResolverAssemblyPopulator
         }
     }
 
-    private static void InferExplicitInterfaceImplementations(TypeDefinition type, ReferenceImporter importer)
+    private static void AddExplicitInterfaceImplementations(TypeDefinition type, TypeAnalysisContext typeContext, ReferenceImporter importer)
     {
-        foreach (var method in type.Methods)
+        foreach (var methodContext in typeContext.Methods)
         {
-            if (Utf8String.IsNullOrEmpty(method.Name))
+            if ((methodContext.Attributes & System.Reflection.MethodAttributes.MemberAccessMask) != System.Reflection.MethodAttributes.Private)
                 continue;
 
-            var periodLastIndex = method.Name.LastIndexOf('.');
-            if (periodLastIndex < 0 || !method.IsPrivate || !method.IsVirtual || !method.IsFinal || !method.IsNewSlot)
+            foreach (var overrideContext in methodContext.Overrides)
             {
-                continue;
-            }
-
-            var methodName = method.Name.Value[(periodLastIndex + 1)..];
-            var interfaceName = method.Name.Value[..periodLastIndex];
-            var genericParameterNames = type.GenericParameters.Count > 0
-                ? type.GenericParameters.Select(p => (string?)p.Name ?? "").ToArray()
-                : [];
-            var interfaceType = AsmResolverUtils.TryLookupTypeSignatureByName(interfaceName, genericParameterNames);
-
-            if (interfaceType is null)
-                continue;
-
-            var ambiguous = false;
-            IMethodDefOrRef? interfaceMethod = null;
-            var underlyingInterface = interfaceType.GetUnderlyingTypeDefOrRef();
-            foreach (var interfaceMethodDef in (underlyingInterface as TypeDefinition)?.Methods ?? [])
-            {
-                if (interfaceMethodDef.Name != methodName)
-                    continue;
-
-                if (interfaceMethod is not null)
+                if (overrideContext.DeclaringType?.IsInterface ?? false)
                 {
-                    // Ambiguity. Checking the method signature will be required to disambiguate.
-                    interfaceMethod = null;
-                    ambiguous = true;
-                    break;
+                    var interfaceMethod = (IMethodDefOrRef)overrideContext.ToMethodDescriptor(importer.TargetModule);
+                    var method = methodContext.GetExtraData<MethodDefinition>("AsmResolverMethod") ?? throw new($"AsmResolver method not found in method analysis context for {methodContext}");
+                    type.MethodImplementations.Add(new MethodImplementation(interfaceMethod, method));
                 }
-
-                // This has the implicit assumption that the method signatures match.
-                // This is a reasonable assumption because there's no other method to match (with this name).
-                interfaceMethod = new MemberReference(importer.ImportType(interfaceType.ToTypeDefOrRef()), interfaceMethodDef.Name, interfaceMethodDef.Signature);
-            }
-
-            if (ambiguous)
-            {
-                // Ambiguities are very rare, so we only bother signature checking when we have to.
-
-                var genericContext = GenericContext.FromType(interfaceType);
-                foreach (var interfaceMethodDef in (underlyingInterface as TypeDefinition)?.Methods ?? [])
-                {
-                    if (interfaceMethodDef.Name != methodName)
-                        continue;
-
-                    if (SignatureComparer.Default.Equals(method.Signature, interfaceMethodDef.Signature?.InstantiateGenericTypes(genericContext)))
-                    {
-                        interfaceMethod = new MemberReference(importer.ImportTypeOrNull(interfaceType?.ToTypeDefOrRef()), interfaceMethodDef.Name, interfaceMethodDef.Signature);
-                        break;
-                    }
-                }
-            }
-
-            if (interfaceMethod != null)
-            {
-                type.MethodImplementations.Add(new MethodImplementation(importer.ImportMethod(interfaceMethod), method));
             }
         }
     }

--- a/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
@@ -558,6 +558,9 @@ public static class AsmResolverAssemblyPopulator
 
     private static void AddExplicitInterfaceImplementations(TypeDefinition type, TypeAnalysisContext typeContext, ReferenceImporter importer)
     {
+        List<(PropertyDefinition InterfaceProperty, TypeSignature InterfaceType, MethodDefinition Method)>? getMethodsToCreate = null;
+        List<(PropertyDefinition InterfaceProperty, TypeSignature InterfaceType, MethodDefinition Method)>? setMethodsToCreate = null;
+
         foreach (var methodContext in typeContext.Methods)
         {
             if ((methodContext.Attributes & System.Reflection.MethodAttributes.MemberAccessMask) != System.Reflection.MethodAttributes.Private)
@@ -570,7 +573,59 @@ public static class AsmResolverAssemblyPopulator
                     var interfaceMethod = (IMethodDefOrRef)overrideContext.ToMethodDescriptor(importer.TargetModule);
                     var method = methodContext.GetExtraData<MethodDefinition>("AsmResolverMethod") ?? throw new($"AsmResolver method not found in method analysis context for {methodContext}");
                     type.MethodImplementations.Add(new MethodImplementation(interfaceMethod, method));
+                    var interfaceMethodResolved = interfaceMethod.Resolve();
+                    if (interfaceMethodResolved != null)
+                    {
+                        if (interfaceMethodResolved.IsGetMethod && !method.IsGetMethod)
+                        {
+                            getMethodsToCreate ??= [];
+                            var interfacePropertyResolved = interfaceMethodResolved.DeclaringType!.Properties.First(p => p.Semantics.Contains(interfaceMethodResolved.Semantics));
+                            getMethodsToCreate.Add((interfacePropertyResolved, interfaceMethod.DeclaringType!.ToTypeSignature(), method));
+                        }
+                        else if (interfaceMethodResolved.IsSetMethod && !method.IsSetMethod)
+                        {
+                            setMethodsToCreate ??= [];
+                            var interfacePropertyResolved = interfaceMethodResolved.DeclaringType!.Properties.First(p => p.Semantics.Contains(interfaceMethodResolved.Semantics));
+                            setMethodsToCreate.Add((interfacePropertyResolved, interfaceMethod.DeclaringType!.ToTypeSignature(), method));
+                        }
+                    }
                 }
+            }
+        }
+
+        // Il2Cpp doesn't include properties for explicit interface implementations, so we have to create them ourselves.
+        if (getMethodsToCreate is not null)
+        {
+            foreach (var entry in getMethodsToCreate)
+            {
+                var (interfaceProperty, interfaceType, getMethod) = entry;
+                var setMethod = setMethodsToCreate?
+                    .FirstOrDefault(e => e.InterfaceProperty == interfaceProperty && SignatureComparer.Default.Equals(e.InterfaceType, interfaceType))
+                    .Method;
+
+                var name = $"{interfaceType.FullName}.{interfaceProperty.Name}";
+                var propertySignature = getMethod.IsStatic
+                    ? PropertySignature.CreateStatic(getMethod.Signature!.ReturnType, getMethod.Signature.ParameterTypes)
+                    : PropertySignature.CreateInstance(getMethod.Signature!.ReturnType, getMethod.Signature.ParameterTypes);
+                var property = new PropertyDefinition(name, interfaceProperty.Attributes, propertySignature);
+                type.Properties.Add(property);
+                property.SetSemanticMethods(getMethod, setMethod);
+            }
+        }
+        if (setMethodsToCreate is not null)
+        {
+            foreach (var entry in setMethodsToCreate)
+            {
+                var (interfaceProperty, interfaceType, setMethod) = entry;
+                if (getMethodsToCreate?.Any(e => e.InterfaceProperty == interfaceProperty && SignatureComparer.Default.Equals(e.InterfaceType, interfaceType)) == true)
+                    continue;
+                var name = $"{interfaceType.FullName}.{interfaceProperty.Name}";
+                var propertySignature = setMethod.IsStatic
+                    ? PropertySignature.CreateStatic(setMethod.Signature!.ParameterTypes[^1], setMethod.Signature.ParameterTypes.Take(setMethod.Signature.ParameterTypes.Count - 1))
+                    : PropertySignature.CreateInstance(setMethod.Signature!.ParameterTypes[^1], setMethod.Signature.ParameterTypes.Take(setMethod.Signature.ParameterTypes.Count - 1));
+                var property = new PropertyDefinition(name, interfaceProperty.Attributes, propertySignature);
+                type.Properties.Add(property);
+                property.SetSemanticMethods(null, setMethod);
             }
         }
     }

--- a/Cpp2IL.Core/Utils/AsmResolver/ContextToMethodDescriptor.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/ContextToMethodDescriptor.cs
@@ -36,7 +36,7 @@ public static class ContextToMethodDescriptor
             context.Name,
             context.BaseMethodContext.ToMethodSignature(parentModule));
 
-        var methodGenericParameters = context.ResolveMethodGenericParameters();
+        var methodGenericParameters = context.MethodGenericParameters;
         if (methodGenericParameters.Length == 0)
         {
             return parentModule.DefaultImporter.ImportMethod(memberReference);

--- a/Cpp2IL.Core/Utils/AttributeInjectionUtils.cs
+++ b/Cpp2IL.Core/Utils/AttributeInjectionUtils.cs
@@ -105,7 +105,8 @@ public static class AttributeInjectionUtils
             newAttribute.ConstructorParameters.Add(enumParameter);
             newAttribute.Properties.Add(new(allowMultipleProperty, new CustomAttributePrimitiveParameter(allowMultiple, newAttribute, CustomAttributeParameterKind.Property, 1)));
             injectedType.AnalyzeCustomAttributeData();
-            injectedType.CustomAttributes!.Add(newAttribute); //Nullability checked above
+            injectedType.CustomAttributes ??= [];
+            injectedType.CustomAttributes.Add(newAttribute);
         }
     }
 

--- a/LibCpp2IL/LibCpp2IL.csproj
+++ b/LibCpp2IL/LibCpp2IL.csproj
@@ -30,7 +30,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AssetRipper.Primitives" Version="3.1.3" />
+        <PackageReference Include="AssetRipper.Primitives" Version="3.1.6" />
         <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     </ItemGroup>
 

--- a/LibCpp2IL/Metadata/Il2CppInterfaceOffset.cs
+++ b/LibCpp2IL/Metadata/Il2CppInterfaceOffset.cs
@@ -1,4 +1,4 @@
-﻿using LibCpp2IL.Reflection;
+using LibCpp2IL.Reflection;
 
 namespace LibCpp2IL.Metadata;
 
@@ -7,11 +7,11 @@ public class Il2CppInterfaceOffset : ReadableClass
     public int typeIndex;
     public int offset;
 
-    public Il2CppTypeReflectionData? type => LibCpp2ILUtils.GetTypeReflectionData(LibCpp2IlMain.Binary!.GetType(typeIndex));
+    public Il2CppTypeReflectionData Type => LibCpp2ILUtils.GetTypeReflectionData(LibCpp2IlMain.Binary!.GetType(typeIndex));
 
     public override string ToString()
     {
-        return $"InterfaceOffsetPair({typeIndex}/{type?.ToString() ?? "unknown type"} => {offset})";
+        return $"InterfaceOffsetPair({typeIndex}/{Type.ToString() ?? "unknown type"} => {offset})";
     }
 
     public override void Read(ClassReadingBinaryReader reader)


### PR DESCRIPTION
* Use vtable to determine overrides
* Fix bug in AttributeInjectionUtils
* Bump NuGet versions to fix some minor issues
* Allow injected concrete generic method contexts
* Allow partially concrete generic method contexts
* Add utility method to TypeAnalysisContext for creating generic instance types
* Override TypeAttributes in GenericInstanceTypeAnalysisContext so that properties like IsInterface function as expected
* Recover explicit property definitions (see https://github.com/AssetRipper/AssetRipper/issues/1682)