### PR TITLE
Add support for the Mach-O universal file format

### DIFF
--- a/LibCpp2IL/LibCpp2IlBinaryRegistry.cs
+++ b/LibCpp2IL/LibCpp2IlBinaryRegistry.cs
@@ -37,6 +37,11 @@ public static class LibCpp2IlBinaryRegistry
             bytes => BitConverter.ToUInt32(bytes, 0) is 0xFEEDFACE or 0xFEEDFACF,
             (memStream) => new MachOFile(memStream)
         );
+
+        Register("Universal Mach-O File", "LibCppIL",
+            bytes => BitConverter.ToUInt32(bytes, 0) is 0xBEBAFECA, // 0xCAFEBABE reversed
+            (memStream) => new MachOUniversalFile(memStream).BestMachOFile
+        );
     }
 
     public static void Register<T>(string name, string source, Func<byte[], bool> isValid, Func<MemoryStream, T> factory) where T : Il2CppBinary

--- a/LibCpp2IL/MachO/MachOUniversalFile.cs
+++ b/LibCpp2IL/MachO/MachOUniversalFile.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using LibCpp2IL.Logging;
+
+namespace LibCpp2IL.MachO;
+
+public class MachOUniversalFile : ClassReadingBinaryReader
+{
+    public MachOFile BestMachOFile { get; }
+
+    public override float MetadataVersion => BestMachOFile?.MetadataVersion ?? 0;
+
+    private static readonly MachOCpuType[] OrderedSupportedCpuTypes =
+    [
+        MachOCpuType.CPU_TYPE_X86_64,
+        MachOCpuType.CPU_TYPE_ARM64,
+        MachOCpuType.CPU_TYPE_I386,
+        MachOCpuType.CPU_TYPE_ARM,
+        MachOCpuType.CPU_TYPE_ARM64_32
+    ];
+
+    public MachOUniversalFile(MemoryStream input) : base(input)
+    {
+        LibLogger.VerboseNewline("Reading universal Mach-O file...");
+
+        LibLogger.VerboseNewline("\tReading universal Mach-O header...");
+        var header = ReadReadable<MachOUniversalHeader>();
+        if (header.NumberFileEntries == 0)
+            throw new("Cannot read a Mach-O file from the universal Mach-O container: no file entries exists.");
+
+        LibLogger.VerboseNewline($"\tFound {header.NumberFileEntries} Mach-O file entries.");
+        var entries = new List<MachOUniversalFileEntry>();
+        LibLogger.VerboseNewline("\tReading Mach-O file entries...");
+        for (var i = 0; i < header.NumberFileEntries; i++)
+            entries.Add(ReadReadable<MachOUniversalFileEntry>());
+
+        LibLogger.VerboseNewline("\tSelecting a suitable Mach-O file entry to read...");
+        var selectedEntry = entries
+            .Where(x => OrderedSupportedCpuTypes.Contains(x.CpuType))
+            .Select(x => (entry: x, supportOrder: Array.IndexOf(OrderedSupportedCpuTypes, x.CpuType)))
+            .OrderBy(x => x.supportOrder)
+            .Select(x => x.entry)
+            .FirstOrDefault();
+
+        if (selectedEntry is null)
+        {
+            selectedEntry = entries[0];
+            LibLogger.WarnNewline($"\tCouldn't find a Mach-O file entry with a supported CPU architecture, " +
+                                  $"falling back to the first entry with CPU type {selectedEntry.CpuType}");
+        }
+        else
+        {
+            LibLogger.VerboseNewline($"\tSelected Mach-O file entry with CPU type: {selectedEntry.CpuType}");
+        }
+
+        LibLogger.VerboseNewline($"\tReading Mach-O file at offset 0x{selectedEntry.FileOffset:X} for 0x{selectedEntry.FileSize:X} bytes");
+        input.Seek((int)selectedEntry.FileOffset, SeekOrigin.Begin);
+        var machOFileBuffer = new byte[selectedEntry.FileSize];
+        var numberBytesRead = input.Read(machOFileBuffer, 0, (int)selectedEntry.FileSize);
+        if (numberBytesRead != (int)selectedEntry.FileSize)
+            LibLogger.WarnNewline($"Read {numberBytesRead} bytes, but expected to read {selectedEntry.FileSize} bytes");
+        var memoryStream = new MemoryStream(machOFileBuffer, 0, (int)selectedEntry.FileSize, false, true);
+        BestMachOFile = new MachOFile(memoryStream);
+    }
+}

--- a/LibCpp2IL/MachO/MachOUniversalFileEntry.cs
+++ b/LibCpp2IL/MachO/MachOUniversalFileEntry.cs
@@ -1,0 +1,19 @@
+namespace LibCpp2IL.MachO;
+
+public class MachOUniversalFileEntry : ReadableClass
+{
+    public MachOCpuType CpuType; //cpu specifier of MachOFile
+    public MachOCpuSubtype CpuSubtype; //cpu specifier of MachOFile
+    public ulong FileOffset; // offset of MachOFile in universal container
+    public ulong FileSize; // size of MachOFile
+    public uint FileAlignment; // alignment of MachOFile
+
+    public override void Read(ClassReadingBinaryReader reader)
+    {
+        CpuType = (MachOCpuType)reader.ReadUInt32WithReversedBits();
+        CpuSubtype = (MachOCpuSubtype)reader.ReadUInt32WithReversedBits();
+        FileOffset = reader.ReadUInt32WithReversedBits();
+        FileSize = reader.ReadUInt32WithReversedBits();
+        FileAlignment = reader.ReadUInt32WithReversedBits();
+    }
+}

--- a/LibCpp2IL/MachO/MachOUniversalHeader.cs
+++ b/LibCpp2IL/MachO/MachOUniversalHeader.cs
@@ -1,0 +1,13 @@
+namespace LibCpp2IL.MachO;
+
+public class MachOUniversalHeader : ReadableClass
+{
+    public uint Magic; //0xCAFEBABE
+    public uint NumberFileEntries; // Number of file entries in the container
+
+    public override void Read(ClassReadingBinaryReader reader)
+    {
+        Magic = reader.ReadUInt32WithReversedBits();
+        NumberFileEntries = reader.ReadUInt32WithReversedBits();
+    }
+}


### PR DESCRIPTION
This pr adds support for the Universal Mach-O file format. This is a format that is structured like a simple archive containing multiple Mach-O files inside of it, but they are specified in such a way that the universal file entry header advertises the CPU architecture. Unity offers the option to compile games in this format so a game can support both x64 or ARM and the correct binary will be selected by the loader. More general information on the format can be found on wikipedia here: https://en.wikipedia.org/wiki/Mach-O#Multi-architecture_binaries

For Cpp2Il's purpose, we only need to select a single MachOFile inside the universal one. It was suggested after discussions to select based on the best supported architecture of the project:
1. x64
2. ARM
3. x86

So we essentially just do a wrapper that finds the best binary and only expose that binary so after opening the stream inside the universal file, everything else behaves just like as if you had a simple mach-o binary. Nothing else really changes.

The universal header is interestingly all in big endian so I read everything with reversed bits. This is also why the header checked is reversed, but in the actual binary, it would read 0xCAFEBABE in big endian.

I mainly did my tests on PapersPlease's binary, but TUNIC is also available to test which I also had good results on