### PR TITLE
Process addresses in the Mach-O export trie as ULEB128 instead of LEB128

### DIFF
--- a/LibCpp2IL/MachO/MachOExportEntry.cs
+++ b/LibCpp2IL/MachO/MachOExportEntry.cs
@@ -1,10 +1,10 @@
 ﻿namespace LibCpp2IL.MachO;
 
-public class MachOExportEntry(string name, long address, long flags, long other, string? importName)
+public class MachOExportEntry(string name, ulong address, ulong flags, ulong other, string? importName)
 {
     public string Name = name;
-    public long Address = address;
-    public long Flags = flags;
-    public long Other = other;
+    public ulong Address = address;
+    public ulong Flags = flags;
+    public ulong Other = other;
     public string? ImportName = importName;
 }

--- a/LibCpp2IL/MachO/MachOExportTrie.cs
+++ b/LibCpp2IL/MachO/MachOExportTrie.cs
@@ -34,23 +34,23 @@ public class MachOExportTrie
         if (terminalSize != 0)
         {
             var flags = (ExportFlags)_reader.BaseStream.ReadLEB128Unsigned();
-            var address = 0L;
-            var other = 0L;
+            var address = 0UL;
+            var other = 0UL;
             string? importName = null;
 
             if ((flags & ExportFlags.ReExport) != 0)
             {
-                other = _reader.BaseStream.ReadLEB128Signed();
+                other = _reader.BaseStream.ReadLEB128Unsigned();
                 importName = _reader.ReadStringToNullAtCurrentPos();
             }
             else
             {
-                address = _reader.BaseStream.ReadLEB128Signed();
+                address = _reader.BaseStream.ReadLEB128Unsigned();
                 if ((flags & ExportFlags.StubAndResolver) != 0)
-                    other = _reader.BaseStream.ReadLEB128Signed();
+                    other = _reader.BaseStream.ReadLEB128Unsigned();
             }
 
-            Entries.Add(new(name, address, (long)flags, other, importName));
+            Entries.Add(new(name, address, (ulong)flags, other, importName));
         }
 
         _reader.BaseStream.Position = childrenIndex;

--- a/LibCpp2IL/MachO/MachOFile.cs
+++ b/LibCpp2IL/MachO/MachOFile.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using LibCpp2IL.Logging;
@@ -16,8 +15,8 @@ public class MachOFile : Il2CppBinary
 
     private readonly MachOSegmentCommand[] Segments64;
     private readonly MachOSection[] Sections64;
-    private readonly Dictionary<string, long> _exportAddressesDict;
-    private readonly Dictionary<long, string> _exportNamesDict;
+    private readonly Dictionary<string, ulong> _exportAddressesDict;
+    private readonly Dictionary<ulong, string> _exportNamesDict;
 
     public MachOFile(MemoryStream input) : base(input)
     {
@@ -79,7 +78,7 @@ public class MachOFile : Il2CppBinary
         var exports = dyldData?.Exports ?? [];
         
         _exportAddressesDict = exports.ToDictionary(e => e.Name[1..], e => e.Address); //Skip the first character, which is a leading underscore inserted by the compiler
-        _exportNamesDict = new Dictionary<long, string>();
+        _exportNamesDict = new Dictionary<ulong, string>();
         foreach (var export in exports) // there may be duplicate names
         {
             _exportNamesDict[export.Address] = export.Name[1..];
@@ -134,19 +133,19 @@ public class MachOFile : Il2CppBinary
         if (!_exportAddressesDict.TryGetValue(toFind, out var addr))
             return 0;
 
-        return (ulong)addr;
+        return addr;
     }
 
-    public override bool IsExportedFunction(ulong addr) => _exportNamesDict.ContainsKey((long)addr);
+    public override bool IsExportedFunction(ulong addr) => _exportNamesDict.ContainsKey(addr);
 
     public override bool TryGetExportedFunctionName(ulong addr, [NotNullWhen(true)] out string? name)
     {
-        return _exportNamesDict.TryGetValue((long)addr, out name);
+        return _exportNamesDict.TryGetValue(addr, out name);
     }
 
     public override IEnumerable<KeyValuePair<string, ulong>> GetExportedFunctions()
     {
-        return _exportAddressesDict.Select(pair => new KeyValuePair<string, ulong>(pair.Key, (ulong)pair.Value));
+        return _exportAddressesDict.Select(pair => new KeyValuePair<string, ulong>(pair.Key, pair.Value));
     }
 
     private MachOSection GetTextSection64()


### PR DESCRIPTION
This is a problem I noticed with TUNIC, but probably other games where the program would report it found some thunks at addresses that made no sense like 0xFFFFFFFFFF something.

Turns out the issue is the addresses were read as LEB128, but the correct encoding is ULEB128. I checked multiple sources confirming they were indeed supposed to be unsigned and the addresses ended up being correct after the fix.