### PR TITLE
Fix fixed buffer fields

### DIFF
--- a/Cpp2IL.Core/Cpp2IL.Core.csproj
+++ b/Cpp2IL.Core/Cpp2IL.Core.csproj
@@ -41,7 +41,7 @@
     <ItemGroup>
         <!--Needed for DLL output-->
         <PackageReference Include="AsmResolver.DotNet" Version="6.0.0-beta.3" />
-        <PackageReference Include="AssetRipper.CIL" Version="1.1.5" />
+        <PackageReference Include="AssetRipper.CIL" Version="1.1.6" />
         
         <!--For ARM64 dissassembly-->
         <PackageReference Include="Disarm" Version="2022.1.0-master.57" />

--- a/Cpp2IL.Core/OutputFormats/AsmResolverDummyDllOutputFormat.cs
+++ b/Cpp2IL.Core/OutputFormats/AsmResolverDummyDllOutputFormat.cs
@@ -93,7 +93,6 @@ public abstract class AsmResolverDllOutputFormat : Cpp2IlOutputFormat
 
         MiscUtils.ExecuteParallel(context.Assemblies, AsmResolverAssemblyPopulator.CopyDataFromIl2CppToManaged);
         MiscUtils.ExecuteParallel(context.Assemblies, AsmResolverAssemblyPopulator.AddExplicitInterfaceImplementations);
-        MiscUtils.ExecuteParallel(context.Assemblies, FillMethodBodies);
 
         Logger.VerboseNewline($"{(DateTime.Now - start).TotalMilliseconds:F1}ms", "DllOutput");
 
@@ -101,6 +100,13 @@ public abstract class AsmResolverDllOutputFormat : Cpp2IlOutputFormat
         start = DateTime.Now;
         Logger.Verbose("Adding custom attributes to all of the above...", "DllOutput");
         MiscUtils.ExecuteParallel(context.Assemblies, AsmResolverAssemblyPopulator.PopulateCustomAttributes);
+
+        Logger.VerboseNewline($"{(DateTime.Now - start).TotalMilliseconds:F1}ms", "DllOutput");
+
+        //Fill method bodies - this should always be done last
+        start = DateTime.Now;
+        Logger.Verbose($"Filling method bodies (in parallel)...", "DllOutput");
+        MiscUtils.ExecuteParallel(context.Assemblies, FillMethodBodies);
 
         Logger.VerboseNewline($"{(DateTime.Now - start).TotalMilliseconds:F1}ms", "DllOutput");
 


### PR DESCRIPTION
Previously, these were unnecessarily initialized in the constructor, causing decompilation issues.

Attributes are used to detect fixed buffer fields, so they have to be applied before filling method bodies.