### PR TITLE
Generic Parameter Fixes and Improvements

### DIFF
--- a/Cpp2IL.Core/Model/Contexts/GenericParameterTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/GenericParameterTypeAnalysisContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using LibCpp2IL.BinaryStructures;
 using LibCpp2IL.Metadata;
 
@@ -15,12 +16,13 @@ public class GenericParameterTypeAnalysisContext : ReferencedTypeAnalysisContext
     public override Il2CppTypeEnum Type { get; }
 
     public GenericParameterTypeAnalysisContext(Il2CppType rawType, AssemblyAnalysisContext referencedFrom)
-        : this(rawType.GetGenericParameterDef(), rawType.Type, referencedFrom)
+        : this(rawType.GetGenericParameterDef(), referencedFrom)
     {
+        Debug.Assert(Type == rawType.Type);
     }
 
-    public GenericParameterTypeAnalysisContext(Il2CppGenericParameter genericParameter, Il2CppTypeEnum type, AssemblyAnalysisContext referencedFrom)
-        : this(genericParameter.Name ?? "T", genericParameter.genericParameterIndexInOwner, type, referencedFrom)
+    public GenericParameterTypeAnalysisContext(Il2CppGenericParameter genericParameter, AssemblyAnalysisContext referencedFrom)
+        : this(genericParameter.Name ?? "T", genericParameter.genericParameterIndexInOwner, genericParameter.Type, referencedFrom)
     {
     }
 

--- a/Cpp2IL.Core/Utils/Il2CppTypeReflectionDataToContext.cs
+++ b/Cpp2IL.Core/Utils/Il2CppTypeReflectionDataToContext.cs
@@ -6,7 +6,7 @@ namespace Cpp2IL.Core.Utils;
 
 public static class Il2CppTypeReflectionDataToContext
 {
-    public static TypeAnalysisContext? ToContext(this Il2CppTypeReflectionData reflectionData, AssemblyAnalysisContext assembly, int genericParamIndex = -1)
+    public static TypeAnalysisContext? ToContext(this Il2CppTypeReflectionData reflectionData, AssemblyAnalysisContext assembly)
     {
         TypeAnalysisContext? pointerElementType;
 
@@ -22,7 +22,7 @@ public static class Il2CppTypeReflectionDataToContext
         }
         else if (!reflectionData.isType)
         {
-            pointerElementType = new GenericParameterTypeAnalysisContext(reflectionData.variableGenericParamName, genericParamIndex, Il2CppTypeEnum.IL2CPP_TYPE_VAR, assembly);
+            pointerElementType = new GenericParameterTypeAnalysisContext(reflectionData.GenericParameter!, assembly);
         }
         else if (!reflectionData.isGenericType)
         {
@@ -39,7 +39,7 @@ public static class Il2CppTypeReflectionDataToContext
             var genericParams = new TypeAnalysisContext[reflectionData.genericParams.Length];
             for (var i = 0; i < reflectionData.genericParams.Length; i++)
             {
-                var param = reflectionData.genericParams[i].ToContext(assembly, i);
+                var param = reflectionData.genericParams[i].ToContext(assembly);
                 if (param == null)
                 {
                     return null;

--- a/LibCpp2IL/Metadata/Il2CppGenericParameter.cs
+++ b/LibCpp2IL/Metadata/Il2CppGenericParameter.cs
@@ -25,6 +25,12 @@ public class Il2CppGenericParameter : ReadableClass
 
     public int Index { get; internal set; }
 
+    public Il2CppGenericContainer Owner => LibCpp2IlMain.TheMetadata!.genericContainers[ownerIndex];
+
+    private bool IsOwnedByMethod => Owner.isGenericMethod != 0;
+
+    public Il2CppTypeEnum Type => IsOwnedByMethod ? Il2CppTypeEnum.IL2CPP_TYPE_MVAR : Il2CppTypeEnum.IL2CPP_TYPE_VAR;
+
     public override void Read(ClassReadingBinaryReader reader)
     {
         ownerIndex = reader.ReadInt32();

--- a/LibCpp2IL/Reflection/Il2CppTypeReflectionData.cs
+++ b/LibCpp2IL/Reflection/Il2CppTypeReflectionData.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using LibCpp2IL.Metadata;
 
 #pragma warning disable 8618
@@ -27,6 +27,8 @@ public class Il2CppTypeReflectionData
     public long variableGenericParamIndex;
     public bool isPointer;
 #pragma warning restore 8618
+
+    public Il2CppGenericParameter? GenericParameter => isArray || isType ? null : LibCpp2IlMain.TheMetadata?.genericParameters[(int)variableGenericParamIndex];
 
     private string GetPtrSuffix()
     {


### PR DESCRIPTION
* Fix `GenericParameterTypeAnalysisContext::Index` when created from `Il2CppTypeReflectionDataToContext`
* Add `Il2CppTypeReflectionData::GenericParameter`
* Add properties to `Il2CppGenericParameter`