### PR TITLE
Don't set a field offset for static fields

### DIFF
--- a/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
@@ -371,7 +371,7 @@ public static class AsmResolverAssemblyPopulator
                 if (managedField.HasFieldRva)
                     managedField.FieldRva = new DataSegment(fieldInfo.Field.StaticArrayInitialValue);
 
-                if (ilTypeDefinition.IsExplicitLayout)
+                if (ilTypeDefinition.IsExplicitLayout && !fieldContext.IsStatic)
                     //Copy field offset
                     managedField.FieldOffset = fieldInfo.FieldOffset;
             }


### PR DESCRIPTION
Only instance fields can have their field offset set.