### PR TITLE
Make HasCustomAttributesAndName::OverrideName virtual

### DIFF
--- a/Cpp2IL.Core/Model/Contexts/ConcreteGenericMethodAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/ConcreteGenericMethodAnalysisContext.cs
@@ -43,6 +43,8 @@ public class ConcreteGenericMethodAnalysisContext : MethodAnalysisContext
 
     public override string DefaultName => BaseMethodContext.DefaultName;
 
+    public override string? OverrideName { get => BaseMethodContext.OverrideName; set => BaseMethodContext.OverrideName = value; }
+
     public override MethodAttributes Attributes => BaseMethodContext.Attributes;
 
     public override AssemblyAnalysisContext CustomAttributeAssembly => BaseMethodContext.CustomAttributeAssembly;

--- a/Cpp2IL.Core/Model/Contexts/HasCustomAttributesAndName.cs
+++ b/Cpp2IL.Core/Model/Contexts/HasCustomAttributesAndName.cs
@@ -1,11 +1,11 @@
-﻿namespace Cpp2IL.Core.Model.Contexts;
+namespace Cpp2IL.Core.Model.Contexts;
 
 public abstract class HasCustomAttributesAndName(uint token, ApplicationAnalysisContext appContext)
     : HasCustomAttributes(token, appContext)
 {
     public abstract string DefaultName { get; }
 
-    public string? OverrideName { get; set; }
+    public virtual string? OverrideName { get; set; }
 
     public string Name => OverrideName ?? DefaultName;
 


### PR DESCRIPTION
This ensures that `ConcreteGenericMethodAnalysisContext::Name` always returns the correct value.