### PR TITLE
Implement some missing property overrides on injected methods

### DIFF
--- a/Cpp2IL.Core/Model/Contexts/AttributeGeneratorMethodAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/AttributeGeneratorMethodAnalysisContext.cs
@@ -1,10 +1,16 @@
+using System.Reflection;
+
 namespace Cpp2IL.Core.Model.Contexts;
 
 public class AttributeGeneratorMethodAnalysisContext : MethodAnalysisContext
 {
     public override ulong UnderlyingPointer { get; }
 
+    protected override bool IsInjected => true;
+    public override bool IsStatic => true;
     public override bool IsVoid => true;
+    public override MethodAttributes Attributes => MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig;
+    protected override int CustomAttributeIndex => -1;
 
     public readonly HasCustomAttributes AssociatedMember;
 

--- a/Cpp2IL.Core/Model/Contexts/HasCustomAttributes.cs
+++ b/Cpp2IL.Core/Model/Contexts/HasCustomAttributes.cs
@@ -68,7 +68,7 @@ public abstract class HasCustomAttributes(uint token, ApplicationAnalysisContext
     /// <summary>
     /// Returns true if this member is injected by Cpp2IL (and thus should not be analyzed for custom attributes).
     /// </summary>
-    protected virtual bool IsInjected { get; } = false;
+    protected virtual bool IsInjected => false;
 
     /// <summary>
     /// Pre-v29, stores the index of the custom attribute range for this member. Post-v29, always -1.

--- a/Cpp2IL.Core/Model/Contexts/InjectedMethodAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/InjectedMethodAnalysisContext.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using LibCpp2IL.BinaryStructures;
 
 namespace Cpp2IL.Core.Model.Contexts;
 
@@ -10,9 +11,13 @@ public class InjectedMethodAnalysisContext : MethodAnalysisContext
 
     public override bool IsStatic { get; }
 
+    public override bool IsVoid => InjectedReturnType?.Type is Il2CppTypeEnum.IL2CPP_TYPE_VOID;
+
     public override MethodAttributes Attributes { get; }
     
     protected override bool IsInjected => true;
+
+    protected override int CustomAttributeIndex => -1;
 
     public InjectedMethodAnalysisContext(TypeAnalysisContext parent, string name, bool isStatic, TypeAnalysisContext returnType, MethodAttributes attributes, TypeAnalysisContext[] injectedParameterTypes, string[]? injectedParameterNames = null) : base(null, parent)
     {

--- a/Cpp2IL.Core/Model/Contexts/NativeMethodAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/NativeMethodAnalysisContext.cs
@@ -10,6 +10,8 @@ public sealed class NativeMethodAnalysisContext : MethodAnalysisContext
 
     public override string DefaultName { get; }
 
+    protected override bool IsInjected => true;
+
     public override bool IsStatic => true;
 
     public override bool IsVoid { get; }


### PR DESCRIPTION
I didn't encounter any issues related to their absence, but they're supposed to be implemented.