### PR TITLE
Fix attribute generator method analysis context return type

### DIFF
--- a/Cpp2IL.Core/Model/Contexts/AttributeGeneratorMethodAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/AttributeGeneratorMethodAnalysisContext.cs
@@ -18,6 +18,7 @@ public class AttributeGeneratorMethodAnalysisContext : MethodAnalysisContext
     {
         UnderlyingPointer = pointer;
         AssociatedMember = associatedMember;
+        InjectedReturnType = AppContext.SystemTypes.SystemVoidType;
         rawMethodBody = AppContext.InstructionSet.GetRawBytesForMethod(this, true);
     }
 }


### PR DESCRIPTION
I discovered an issue while working on #445. An exception can be thrown here:

https://github.com/SamboyCoding/Cpp2IL/blob/e93c0fecc9d6c5afb6914acb278c8afaa8894cdd/Cpp2IL.Core/InstructionSets/NewArmV8InstructionSet.cs#L439