### PR TITLE
Update IsRef property in InjectedParameterAnalysisContext

### DIFF
--- a/Cpp2IL.Core/Model/Contexts/InjectedParameterAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/InjectedParameterAnalysisContext.cs
@@ -8,7 +8,7 @@ public class InjectedParameterAnalysisContext : ParameterAnalysisContext
 {
     public override TypeAnalysisContext ParameterTypeContext { get; }
 
-    public override bool IsRef => ParameterTypeContext is ReferencedTypeAnalysisContext;
+    public override bool IsRef => ParameterTypeContext is ByRefTypeAnalysisContext;
 
     public override ParameterAttributes ParameterAttributes => ParameterAttributes.None;
     

--- a/Cpp2IL.Core/Model/Contexts/InjectedParameterAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/InjectedParameterAnalysisContext.cs
@@ -8,8 +8,6 @@ public class InjectedParameterAnalysisContext : ParameterAnalysisContext
 {
     public override TypeAnalysisContext ParameterTypeContext { get; }
 
-    public override bool IsRef => ParameterTypeContext is ByRefTypeAnalysisContext;
-
     public override ParameterAttributes ParameterAttributes => ParameterAttributes.None;
     
     protected override bool IsInjected => true;

--- a/Cpp2IL.Core/Model/Contexts/ParameterAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/ParameterAnalysisContext.cs
@@ -52,7 +52,7 @@ public class ParameterAnalysisContext : HasCustomAttributesAndName, IParameterIn
     /// <summary>
     /// True if this parameter is passed by reference.
     /// </summary>
-    public virtual bool IsRef => ParameterType.Byref == 1 || ParameterAttributes.HasFlag(ParameterAttributes.Out);
+    public bool IsRef => ParameterTypeContext is ByRefTypeAnalysisContext || ParameterAttributes.HasFlag(ParameterAttributes.Out);
 
     /// <summary>
     /// The default value data for this parameter. Null if, and only if, the parameter has no default value. If it has a default value of literally null, this will be non-null and have a data index of -1.


### PR DESCRIPTION
Modified the IsRef property to check for ByRefTypeAnalysisContext instead of ReferencedTypeAnalysisContext, correcting the behavior of reference parameter handling.