### PR TITLE
Handle self-referencing generic classes

### DIFF
--- a/Cpp2IL.Core/Model/Contexts/AssemblyAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/AssemblyAnalysisContext.cs
@@ -65,6 +65,9 @@ public class AssemblyAnalysisContext : HasCustomAttributesAndName
 
     private readonly Dictionary<Il2CppTypeDefinition, TypeAnalysisContext> TypesByDefinition = new();
 
+    /// <summary>
+    /// Cache for <see cref="GenericInstanceTypeAnalysisContext.GetOrCreate(Il2CppType, AssemblyAnalysisContext)"/>
+    /// </summary>
     internal readonly Dictionary<Il2CppType, GenericInstanceTypeAnalysisContext> GenericInstanceTypesByIl2CppType = new();
 
     public override string DefaultName => Definition?.AssemblyName.Name ?? throw new($"Injected assemblies should override {nameof(DefaultName)}");

--- a/Cpp2IL.Core/Model/Contexts/AssemblyAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/AssemblyAnalysisContext.cs
@@ -65,6 +65,8 @@ public class AssemblyAnalysisContext : HasCustomAttributesAndName
 
     private readonly Dictionary<Il2CppTypeDefinition, TypeAnalysisContext> TypesByDefinition = new();
 
+    internal readonly Dictionary<Il2CppType, GenericInstanceTypeAnalysisContext> GenericInstanceTypesByIl2CppType = new();
+
     public override string DefaultName => Definition?.AssemblyName.Name ?? throw new($"Injected assemblies should override {nameof(DefaultName)}");
 
     protected override bool IsInjected => Definition is null;

--- a/Cpp2IL.Core/Model/Contexts/AssemblyAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/AssemblyAnalysisContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -68,7 +69,7 @@ public class AssemblyAnalysisContext : HasCustomAttributesAndName
     /// <summary>
     /// Cache for <see cref="GenericInstanceTypeAnalysisContext.GetOrCreate(Il2CppType, AssemblyAnalysisContext)"/>
     /// </summary>
-    internal readonly Dictionary<Il2CppType, GenericInstanceTypeAnalysisContext> GenericInstanceTypesByIl2CppType = new();
+    internal readonly ConcurrentDictionary<Il2CppType, GenericInstanceTypeAnalysisContext> GenericInstanceTypesByIl2CppType = new();
 
     public override string DefaultName => Definition?.AssemblyName.Name ?? throw new($"Injected assemblies should override {nameof(DefaultName)}");
 

--- a/Cpp2IL.Core/Model/Contexts/GenericInstanceTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/GenericInstanceTypeAnalysisContext.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -56,6 +57,9 @@ public class GenericInstanceTypeAnalysisContext : ReferencedTypeAnalysisContext
 
     public static GenericInstanceTypeAnalysisContext GetOrCreate(Il2CppType rawType, AssemblyAnalysisContext referencedFrom)
     {
+        if (rawType.Type != Il2CppTypeEnum.IL2CPP_TYPE_GENERICINST)
+            throw new ArgumentException($"Cannot create {nameof(GenericInstanceTypeAnalysisContext)} from type {rawType.Type}. Expected {Il2CppTypeEnum.IL2CPP_TYPE_GENERICINST}.");
+
         if (!referencedFrom.GenericInstanceTypesByIl2CppType.TryGetValue(rawType, out var result))
         {
             result = new GenericInstanceTypeAnalysisContext(rawType, referencedFrom);

--- a/Cpp2IL.Core/Model/Contexts/GenericInstanceTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/GenericInstanceTypeAnalysisContext.cs
@@ -35,7 +35,7 @@ public class GenericInstanceTypeAnalysisContext : ReferencedTypeAnalysisContext
     {
         // Cache this instance before resolving anything else, which might contain a reference to this instance.
         // https://github.com/SamboyCoding/Cpp2IL/issues/469
-        referencedFrom.GenericInstanceTypesByIl2CppType.Add(rawType, this);
+        referencedFrom.GenericInstanceTypesByIl2CppType.TryAdd(rawType, this);
 
         //Generic type has to be a type definition
         var gClass = rawType.GetGenericClass();

--- a/Cpp2IL.Core/Model/Contexts/GenericInstanceTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/GenericInstanceTypeAnalysisContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -29,8 +30,12 @@ public class GenericInstanceTypeAnalysisContext : ReferencedTypeAnalysisContext
 
     public sealed override bool IsValueType => GenericType.IsValueType; //We don't set a definition so the default implementation cannot determine if we're a value type or not. 
 
-    public GenericInstanceTypeAnalysisContext(Il2CppType rawType, AssemblyAnalysisContext referencedFrom) : base(referencedFrom)
+    private GenericInstanceTypeAnalysisContext(Il2CppType rawType, AssemblyAnalysisContext referencedFrom) : base(referencedFrom)
     {
+        // Cache this instance before resolving anything else, which might contain a reference to this instance.
+        // https://github.com/SamboyCoding/Cpp2IL/issues/469
+        referencedFrom.GenericInstanceTypesByIl2CppType.Add(rawType, this);
+
         //Generic type has to be a type definition
         var gClass = rawType.GetGenericClass();
         GenericType = AppContext.ResolveContextForType(gClass.TypeDefinition) ?? throw new($"Could not resolve type {gClass.TypeDefinition.FullName} for generic instance base type");
@@ -47,6 +52,17 @@ public class GenericInstanceTypeAnalysisContext : ReferencedTypeAnalysisContext
         DefaultBaseType = genericType.BaseType;
 
         SetDeclaringType();
+    }
+
+    public static GenericInstanceTypeAnalysisContext GetOrCreate(Il2CppType rawType, AssemblyAnalysisContext referencedFrom)
+    {
+        if (!referencedFrom.GenericInstanceTypesByIl2CppType.TryGetValue(rawType, out var result))
+        {
+            result = new GenericInstanceTypeAnalysisContext(rawType, referencedFrom);
+            Debug.Assert(referencedFrom.GenericInstanceTypesByIl2CppType.ContainsKey(rawType), $"The {nameof(GenericInstanceTypeAnalysisContext)} constructor should add itself to the dictionary.");
+        }
+
+        return result;
     }
 
     public override string GetCSharpSourceString()

--- a/Cpp2IL.Core/Model/Contexts/GenericInstanceTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/GenericInstanceTypeAnalysisContext.cs
@@ -55,6 +55,12 @@ public class GenericInstanceTypeAnalysisContext : ReferencedTypeAnalysisContext
         SetDeclaringType();
     }
 
+    /// <summary>
+    /// Get or create a <see cref="GenericInstanceTypeAnalysisContext"/> from an <see cref="Il2CppType"/>.
+    /// </summary>
+    /// <param name="rawType">The underlying <see cref="Il2CppType"/>.</param>
+    /// <param name="referencedFrom">The assembly that is referencing this generic instance.</param>
+    /// <returns>The context for the <paramref name="rawType"/>.</returns>
     public static GenericInstanceTypeAnalysisContext GetOrCreate(Il2CppType rawType, AssemblyAnalysisContext referencedFrom)
     {
         if (rawType.Type != Il2CppTypeEnum.IL2CPP_TYPE_GENERICINST)

--- a/Cpp2IL.Core/Utils/Il2CppTypeToContext.cs
+++ b/Cpp2IL.Core/Utils/Il2CppTypeToContext.cs
@@ -20,7 +20,7 @@ public static class Il2CppTypeToContext
         else if (type.Type is Il2CppTypeEnum.IL2CPP_TYPE_CLASS or Il2CppTypeEnum.IL2CPP_TYPE_VALUETYPE)
             ret = context.AppContext.ResolveContextForType(type.AsClass()) ?? throw new($"Could not resolve type context for type {type.AsClass().FullName}");
         else if (type.Type is Il2CppTypeEnum.IL2CPP_TYPE_GENERICINST)
-            ret = new GenericInstanceTypeAnalysisContext(type, context);
+            ret = GenericInstanceTypeAnalysisContext.GetOrCreate(type, context);
         else if (type.Type is Il2CppTypeEnum.IL2CPP_TYPE_BYREF or Il2CppTypeEnum.IL2CPP_TYPE_PTR or Il2CppTypeEnum.IL2CPP_TYPE_SZARRAY or Il2CppTypeEnum.IL2CPP_TYPE_ARRAY)
             ret = WrappedTypeAnalysisContext.Create(type, context);
         else


### PR DESCRIPTION
Resolves #469 

This was caused by a generic class referencing itself.

```cs
public abstract class RegionDialogContext<TStage> : DialogContext<RegionDialogContext<TStage>.State> where TStage : StageContext, new()
{
	public class State
	{
	}
}
```