### PR TITLE
Check for HasDefault flag when emitting parameters

### DIFF
--- a/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
@@ -374,7 +374,7 @@ public static class AsmResolverAssemblyPopulator
                 var sequence = (ushort)(i + 1); //Add one because sequence 0 is the return type
                 parameterDefinitions[i] = new(sequence, parameterAnalysisContext.Name, (ParameterAttributes)parameterAnalysisContext.Attributes);
 
-                if (parameterAnalysisContext.DefaultValue is not { } defaultValueData)
+                if (parameterAnalysisContext.DefaultValue is not { } defaultValueData || !parameterAnalysisContext.Attributes.HasFlag(System.Reflection.ParameterAttributes.HasDefault))
                     continue;
 
                 if (defaultValueData?.ContainedDefaultValue is { } constVal)


### PR DESCRIPTION
This prevents issues changing the parameter types.