### PR TITLE
Add ARM64 (aarch64) support for cross-platform releases

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -11,7 +11,7 @@ jobs:
   release-net9:
     strategy:     
       matrix:
-        runtimeIdentifier: [linux-x64, osx-x64, win-x64]
+        runtimeIdentifier: [linux-x64, linux-arm64, osx-x64, osx-arm64, win-x64, win-arm64]
         project: [Cpp2IL]
     name: Build Single-File Artifact
     runs-on: ubuntu-latest

--- a/do-release.ps1
+++ b/do-release.ps1
@@ -97,17 +97,29 @@ $baseVersion = (Select-Xml -XPath "//Project/PropertyGroup/VersionPrefix" -Path 
 $fullVersionString = "$baseVersion-$version"
 Write-Host "Building Cpp2IL command line executable, release version $fullVersionString"
 
-Write-Host "    Building Cpp2IL - Windows, Standalone .NET"
+Write-Host "    Building Cpp2IL - Windows x64, Standalone .NET"
 
 $null = dotnet publish -c Release -f "net9.0" -r "win-x64" /p:VersionSuffix=$version /p:PublishSingleFile=true --self-contained
 
-Write-Host "    Building Cpp2IL - Linux, Standalone .NET"
+Write-Host "    Building Cpp2IL - Windows ARM64, Standalone .NET"
+
+$null = dotnet publish -c Release -f "net9.0" -r "win-arm64" /p:VersionSuffix=$version /p:PublishSingleFile=true --self-contained
+
+Write-Host "    Building Cpp2IL - Linux x64, Standalone .NET"
 
 $null = dotnet publish -c Release -f "net9.0" -r "linux-x64" /p:VersionSuffix=$version /p:PublishSingleFile=true --self-contained
 
-Write-Host "    Building Cpp2IL - MacOS, Standalone .NET"
+Write-Host "    Building Cpp2IL - Linux ARM64, Standalone .NET"
+
+$null = dotnet publish -c Release -f "net9.0" -r "linux-arm64" /p:VersionSuffix=$version /p:PublishSingleFile=true --self-contained
+
+Write-Host "    Building Cpp2IL - MacOS x64, Standalone .NET"
 
 $null = dotnet publish -c Release -f "net9.0" -r "osx-x64" /p:VersionSuffix=$version /p:PublishSingleFile=true --self-contained
+
+Write-Host "    Building Cpp2IL - MacOS ARM64, Standalone .NET"
+
+$null = dotnet publish -c Release -f "net9.0" -r "osx-arm64" /p:VersionSuffix=$version /p:PublishSingleFile=true --self-contained
 
 Write-Host "    Building Cpp2IL - Windows, .NET Framework"
 
@@ -146,8 +158,11 @@ function ZipAndRename($rid, $platform, $releasePlatformString, $extension)
 Write-Host "Moving files to artifacts directory"
 
 CopyAndRename "net9.0" "win-x64" "Windows" ".exe"
+CopyAndRename "net9.0" "win-arm64" "Windows-ARM64" ".exe"
 CopyAndRename "net9.0" "linux-x64" "Linux" ""
+CopyAndRename "net9.0" "linux-arm64" "Linux-ARM64" ""
 CopyAndRename "net9.0" "osx-x64" "OSX" ""
+CopyAndRename "net9.0" "osx-arm64" "OSX-ARM64" ""
 ZipAndRename "net472" "win-x64" "Windows-Netframework472" ".exe"
 
 Set-Location $ProjectRoot


### PR DESCRIPTION
Addresses #479 

This commit adds ARM64 support to enable native execution on ARM64 devices such as Apple Silicon Macs, ARM64 Linux systems (Raspberry Pi), and Windows on ARM devices.

Changes made:
- Add ARM64 runtime identifiers (linux-arm64, osx-arm64, win-arm64) to GitHub Actions workflow
- Update PowerShell release script to build and package ARM64 executables
- Suppress NU5104 warnings for prerelease dependencies required for ARM64 disassembly support
- Fix nullable reference warnings and code analysis issues introduced by dependency updates

Benefits:
- LemonLoader Compatibility: Enables integration via pre-built ARM64 binaries instead of fixed NuGet versions
- Broader Device Support: Native execution on ARM64 devices without box64/box86 emulation
- Improved Performance: Native ARM64 execution is significantly faster than x64 emulation

Technical Details:
ARM64 disassembly support requires beta versions of AsmResolver.DotNet and Disarm packages, which contain ARM64-specific functionality not yet available in stable releases. The warning fixes ensure no build regressions are introduced while maintaining code quality standards.