### PR TITLE
Allow method overrides to be modified

### DIFF
--- a/Cpp2IL.Core/Model/Contexts/InjectedMethodAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/InjectedMethodAnalysisContext.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace Cpp2IL.Core.Model.Contexts;
@@ -18,9 +17,6 @@ public class InjectedMethodAnalysisContext : MethodAnalysisContext
     protected override bool IsInjected => true;
 
     protected override int CustomAttributeIndex => -1;
-
-    public override IEnumerable<MethodAnalysisContext> Overrides => OverridesList;
-    public List<MethodAnalysisContext> OverridesList { get; } = [];
 
     public InjectedMethodAnalysisContext(
         TypeAnalysisContext parent,

--- a/Cpp2IL.Core/Model/Contexts/MethodAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/MethodAnalysisContext.cs
@@ -122,84 +122,92 @@ public class MethodAnalysisContext : HasGenericParameters, IMethodInfoProvider
 
     public MethodAnalysisContext? BaseMethod => Overrides.FirstOrDefault(m => m.DeclaringType?.IsInterface is false);
 
+    private List<MethodAnalysisContext>? _overrides;
+
     /// <summary>
     /// The set of methods which this method overrides.
     /// </summary>
-    public virtual IEnumerable<MethodAnalysisContext> Overrides
+    public List<MethodAnalysisContext> Overrides
     {
         get
         {
-            if (Definition == null)
-                return [];
+            // Lazy load the overrides
+            return _overrides ??= GetOverrides().ToList();
+        }
+    }
 
-            var declaringTypeDefinition = DeclaringType?.Definition;
-            if (declaringTypeDefinition == null)
-                return [];
+    private IEnumerable<MethodAnalysisContext> GetOverrides()
+    {
+        if (Definition == null)
+            return [];
 
-            var vtable = declaringTypeDefinition.VTable;
-            if (vtable == null)
-                return [];
+        var declaringTypeDefinition = DeclaringType?.Definition;
+        if (declaringTypeDefinition == null)
+            return [];
 
-            return GetOverriddenMethods(declaringTypeDefinition, vtable);
+        var vtable = declaringTypeDefinition.VTable;
+        if (vtable == null)
+            return [];
 
-            bool TryGetMethodForSlot(TypeAnalysisContext declaringType, int slot, [NotNullWhen(true)] out MethodAnalysisContext? method)
+        return GetOverriddenMethods(declaringTypeDefinition, vtable);
+
+        bool TryGetMethodForSlot(TypeAnalysisContext declaringType, int slot, [NotNullWhen(true)] out MethodAnalysisContext? method)
+        {
+            if (declaringType is GenericInstanceTypeAnalysisContext genericInstanceType)
             {
-                if (declaringType is GenericInstanceTypeAnalysisContext genericInstanceType)
+                var genericMethod = genericInstanceType.GenericType.Methods.FirstOrDefault(m => m.Slot == slot);
+                if (genericMethod is not null)
                 {
-                    var genericMethod = genericInstanceType.GenericType.Methods.FirstOrDefault(m => m.Slot == slot);
-                    if (genericMethod is not null)
-                    {
-                        method = new ConcreteGenericMethodAnalysisContext(genericMethod, genericInstanceType.GenericArguments, []);
-                        return true;
-                    }
+                    method = new ConcreteGenericMethodAnalysisContext(genericMethod, genericInstanceType.GenericArguments, []);
+                    return true;
                 }
-                else
+            }
+            else
+            {
+                var baseMethod = declaringType.Methods.FirstOrDefault(m => m.Slot == slot);
+                if (baseMethod is not null)
                 {
-                    var baseMethod = declaringType.Methods.FirstOrDefault(m => m.Slot == slot);
-                    if (baseMethod is not null)
-                    {
-                        method = baseMethod;
-                        return true;
-                    }
+                    method = baseMethod;
+                    return true;
                 }
-
-                method = null;
-                return false;
             }
 
-            IEnumerable<MethodAnalysisContext> GetOverriddenMethods(Il2CppTypeDefinition declaringTypeDefinition, MetadataUsage?[] vtable)
+            method = null;
+            return false;
+        }
+
+        IEnumerable<MethodAnalysisContext> GetOverriddenMethods(Il2CppTypeDefinition declaringTypeDefinition, MetadataUsage?[] vtable)
+        {
+            for (var i = 0; i < vtable.Length; ++i)
             {
-                for (var i = 0; i < vtable.Length; ++i)
+                var vtableEntry = vtable[i];
+                if (vtableEntry is null or { Type: not MetadataUsageType.MethodDef })
+                    continue;
+
+                if (vtableEntry.AsMethod() != Definition)
+                    continue;
+
+                // Normal inheritance
+                var baseType = DeclaringType?.BaseType;
+                while (baseType is not null)
                 {
-                    var vtableEntry = vtable[i];
-                    if (vtableEntry is null or { Type: not MetadataUsageType.MethodDef })
-                        continue;
-
-                    if (vtableEntry.AsMethod() != Definition)
-                        continue;
-
-                    // Normal inheritance
-                    var baseType = DeclaringType?.BaseType;
-                    while (baseType is not null)
+                    if (TryGetMethodForSlot(baseType, i, out var method))
                     {
-                        if (TryGetMethodForSlot(baseType, i, out var method))
+                        yield return method;
+                        break; // We only want direct overrides, not the entire inheritance chain.
+                    }
+                    baseType = baseType.BaseType;
+                }
+
+                // Interface inheritance
+                foreach (var interfaceOffset in declaringTypeDefinition.InterfaceOffsets)
+                {
+                    if (i >= interfaceOffset.offset)
+                    {
+                        var interfaceTypeContext = interfaceOffset.Type.ToContext(CustomAttributeAssembly);
+                        if (interfaceTypeContext != null && TryGetMethodForSlot(interfaceTypeContext, i - interfaceOffset.offset, out var method))
                         {
                             yield return method;
-                            break; // We only want direct overrides, not the entire inheritance chain.
-                        }
-                        baseType = baseType.BaseType;
-                    }
-
-                    // Interface inheritance
-                    foreach (var interfaceOffset in declaringTypeDefinition.InterfaceOffsets)
-                    {
-                        if (i >= interfaceOffset.offset)
-                        {
-                            var interfaceTypeContext = interfaceOffset.Type.ToContext(CustomAttributeAssembly);
-                            if (interfaceTypeContext != null && TryGetMethodForSlot(interfaceTypeContext, i - interfaceOffset.offset, out var method))
-                            {
-                                yield return method;
-                            }
                         }
                     }
                 }

--- a/Cpp2IL.Core/Model/Contexts/MethodAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/MethodAnalysisContext.cs
@@ -188,7 +188,7 @@ public class MethodAnalysisContext : HasGenericParameters, IMethodInfoProvider
                     continue;
 
                 // Normal inheritance
-                var baseType = DeclaringType?.BaseType;
+                var baseType = DeclaringType?.DefaultBaseType;
                 while (baseType is not null)
                 {
                     if (TryGetMethodForSlot(baseType, i, out var method))
@@ -196,7 +196,7 @@ public class MethodAnalysisContext : HasGenericParameters, IMethodInfoProvider
                         yield return method;
                         break; // We only want direct overrides, not the entire inheritance chain.
                     }
-                    baseType = baseType.BaseType;
+                    baseType = baseType.DefaultBaseType;
                 }
 
                 // Interface inheritance


### PR DESCRIPTION
I moved the overrides finding logic into a helper method and made the property a lazily initialized list. I also switched BaseType with DefaultBaseType for consistent lazy loading.