### PR TITLE
Fix incorrect address translation at segment boundary

### DIFF
--- a/LibCpp2IL/NintendoSwitch/NsoFile.cs
+++ b/LibCpp2IL/NintendoSwitch/NsoFile.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -309,7 +309,7 @@ public sealed class NsoFile : Il2CppBinary
 
     public override long MapVirtualAddressToRaw(ulong addr, bool throwOnError = true)
     {
-        var segment = segments.FirstOrDefault(x => addr - NsoGlobalOffset >= x.MemoryOffset && addr - NsoGlobalOffset <= x.MemoryOffset + x.DecompressedSize);
+        var segment = segments.FirstOrDefault(x => addr - NsoGlobalOffset >= x.MemoryOffset && addr - NsoGlobalOffset < x.MemoryOffset + x.DecompressedSize);
         if (segment == null)
             if (throwOnError)
                 throw new InvalidOperationException($"NSO: Address 0x{addr:X} is not present in any of the segments. Known segment ends are (hex) {string.Join(", ", segments.Select(s => (s.MemoryOffset + s.DecompressedSize).ToString("X")))}");
@@ -321,7 +321,7 @@ public sealed class NsoFile : Il2CppBinary
 
     public override ulong MapRawAddressToVirtual(uint offset)
     {
-        var segment = segments.FirstOrDefault(x => offset >= x.FileOffset && offset <= x.FileOffset + x.DecompressedSize);
+        var segment = segments.FirstOrDefault(x => offset >= x.FileOffset && offset < x.FileOffset + x.DecompressedSize);
         if (segment == null)
         {
             return 0;

--- a/LibCpp2IL/PE/PE.cs
+++ b/LibCpp2IL/PE/PE.cs
@@ -97,7 +97,7 @@ public sealed class PE : Il2CppBinary
             return VirtToRawInvalidOutOfBounds;
         }
 
-        var section = peSectionHeaders.FirstOrDefault(x => addr >= x.VirtualAddress && addr <= x.VirtualAddress + x.VirtualSize);
+        var section = peSectionHeaders.FirstOrDefault(x => addr >= x.VirtualAddress && addr < x.VirtualAddress + x.VirtualSize);
 
         if (section == null) return 0L;
 


### PR DESCRIPTION
While trying to install MelonLoader, I found incorrect address translation behavior for addresses at the start/end of a segment.

I have tested PE address translation against multiple GameAssembly DLLs, but I have not tested against NSO binaries.