### PR TITLE
Fix metadata version not populated, breaking all past versions

### DIFF
--- a/LibCpp2IL/Il2CppBinary.cs
+++ b/LibCpp2IL/Il2CppBinary.cs
@@ -60,15 +60,15 @@ public abstract class Il2CppBinary(MemoryStream input) : ClassReadingBinaryReade
     /// </summary>
     public virtual ClassReadingBinaryReader Reader => this;
 
-    private float _metadataVersion;
-    public sealed override float MetadataVersion => _metadataVersion; 
+    private float? _metadataVersion;
+    public sealed override float MetadataVersion => _metadataVersion ?? 0;
+
+    internal void SetMetadataVersion(float version) => _metadataVersion = version;
 
     public int InBinaryMetadataSize { get; private set; }
 
     public void Init(ulong pCodeRegistration, ulong pMetadataRegistration, Il2CppMetadata metadata)
     {
-        _metadataVersion = metadata.MetadataVersion;
-        
         var cr = pCodeRegistration > 0 ? ReadReadableAtVirtualAddress<Il2CppCodeRegistration>(pCodeRegistration) : null;
         var mr = pMetadataRegistration > 0 ? ReadReadableAtVirtualAddress<Il2CppMetadataRegistration>(pMetadataRegistration) : null;
 
@@ -487,6 +487,9 @@ public abstract class Il2CppBinary(MemoryStream input) : ClassReadingBinaryReade
 
     public virtual (ulong pCodeRegistration, ulong pMetadataRegistration) FindCodeAndMetadataReg(Il2CppMetadata metadata)
     {
+        if (!_metadataVersion.HasValue)
+            throw new InvalidOperationException("MetadataVersion must be set before searching for code and metadata registration. Call SetMetadataVersion first.");
+
         LibLogger.VerboseNewline("\tAttempting to locate code and metadata registration functions...");
 
         var methodCount = metadata.methodDefs.Count(x => x.methodIndex >= 0);

--- a/LibCpp2IL/LibCpp2IlBinaryRegistry.cs
+++ b/LibCpp2IL/LibCpp2IlBinaryRegistry.cs
@@ -67,6 +67,7 @@ public static class LibCpp2IlBinaryRegistry
         var start = DateTime.Now;
 
         var binary = match.FactoryFunc(memStream);
+        binary.SetMetadataVersion(metadata.MetadataVersion);
 
         LibCpp2IlMain.Binary = binary;
 


### PR DESCRIPTION
I noticed a regression in CPP2IL [2022.1.0 #20](https://github.com/SamboyCoding/Cpp2IL/releases/tag/2022.1.0-pre-release.20) where it can't find the codereg address for my Nintendo Switch binary with Unity 2019.4.27, while the previous milestone [2022.1.0 #19](https://github.com/SamboyCoding/Cpp2IL/releases/tag/2022.1.0-pre-release.19) did.

I further narrowed down the regression to https://github.com/AssetRipper/AssetRipper/compare/1.1.8...1.1.9.

When I diffed the code, I came across this issue:

Commit c91170a changed `ReadableClass` version checking from using the global static `LibCpp2IlMain.MetadataVersion` to using an instance property `MetadataVersion`. The instance property is set from the binary reader's `MetadataVersion` when the struct is created in `InternalReadReadableClass<T>()`.

However, `Il2CppBinary._metadataVersion` is only set in `Init()`, which runs after `FindCodeAndMetadataReg()`. So during code registration search, the binary's `MetadataVersion` is 0 (default), causing all version-gated fields to be read incorrectly. This likely breaks all past (non-current) metadata versions.

To fix, I added the missing setter call, and reworked `FindCodeAndMetadataReg()` to raise an exception in case this ever happens again.

@ds5678 tagging for visibility as this probably has a pretty big impact on AssetRipper.