### PR TITLE
Fix ArmV8 segment boundary crash

### DIFF
--- a/Cpp2IL.Core/InstructionSets/NewArmV8InstructionSet.cs
+++ b/Cpp2IL.Core/InstructionSets/NewArmV8InstructionSet.cs
@@ -32,10 +32,12 @@ public class NewArmV8InstructionSet : Cpp2IlInstructionSet
         }
 
         var result = NewArm64Utils.GetArm64MethodBodyAtVirtualAddress(context.UnderlyingPointer);
-        var endVa = result.LastValid().Address + 4;
+        var lastInsn = result.LastValid();
 
         var start = (int)context.AppContext.Binary.MapVirtualAddressToRaw(context.UnderlyingPointer);
-        var end = (int)context.AppContext.Binary.MapVirtualAddressToRaw(endVa);
+        // Map the last instruction (always within segment) and add 4 (ARM64 instruction size).
+        // This avoids mapping endVa which may land exactly at a segment boundary gap.
+        var end = (int)context.AppContext.Binary.MapVirtualAddressToRaw(lastInsn.Address) + 4;
 
         //Sanity check
         if (start < 0 || end < 0 || start >= context.AppContext.Binary.RawLength || end >= context.AppContext.Binary.RawLength)


### PR DESCRIPTION
I hit another regression with the binary from #515.

This was caused by 8478bd6, although in reality segment boundaries were never handled properly and this worked before "by accident". The error:
> Unhandled exception. System.InvalidOperationException: NSO: Address 0x2B83E14 is not present in any of the segments. Known segment ends are (hex) 2B83E14, 446F004, 49AF3F8

I checked section dump:
```
         file off file len mem off  mem len  bss/algn
0 [r-x]:      100  2b83e14        0  2b83e14      100
1 [r--]:  2b84100  18eb004  2b84000  18eb004        0
2 [rw-]:  4470100   53f3f8  4470000   53f3f8   409c08
.rodata-relative:
  .dynstr:   c34520     b80d
  .dynsym:   c2e1f0     6330
```

So, it looks like we are calculating the end of the method body to be the address just after `.text` ends. This is, in fact, the correct address, but it does also legitimately fall just outside the segment bounds. This is why we now get `InvalidOperationException` exception. Before, because of the `<=`, this would work fine, but then our segment bounds were off by 4 bytes.

To fix properly, I resolve the last instruction (always valid) and then add +4 in raw space, which won't trip the exception.