### PR TITLE
Initialize arrays as empty when count is zero

### DIFF
--- a/LibCpp2IL/Il2CppBinary.cs
+++ b/LibCpp2IL/Il2CppBinary.cs
@@ -197,6 +197,10 @@ public abstract class Il2CppBinary(MemoryStream input) : ClassReadingBinaryReade
                         _codeGenModuleMethodPointers[i] = new ulong[codeGenModule.methodPointerCount];
                     }
                 }
+                else
+                {
+                    _codeGenModuleMethodPointers[i] = [];
+                }
 
                 if (codeGenModule.rgctxRangesCount > 0)
                 {
@@ -212,6 +216,10 @@ public abstract class Il2CppBinary(MemoryStream input) : ClassReadingBinaryReade
                         _codegenModuleRgctxRanges[i] = new Il2CppTokenRangePair[codeGenModule.rgctxRangesCount];
                     }
                 }
+                else
+                {
+                    _codegenModuleRgctxRanges[i] = [];
+                }
 
                 if (codeGenModule.rgctxsCount > 0)
                 {
@@ -226,6 +234,10 @@ public abstract class Il2CppBinary(MemoryStream input) : ClassReadingBinaryReade
                         LibLogger.VerboseNewline($"\t\t\tWARNING: Unable to get RGCTXs for {name}: {e.Message}");
                         _codegenModuleRgctxs[i] = new Il2CppRGCTXDefinition[codeGenModule.rgctxsCount];
                     }
+                }
+                else
+                {
+                    _codegenModuleRgctxs[i] = [];
                 }
             }
 


### PR DESCRIPTION
Ensure _codeGenModuleMethodPointers, _codegenModuleRgctxRanges, and _codegenModuleRgctxs are always initialized, even when their respective counts are zero, by assigning empty arrays. This prevents potential null reference issues.