### PR TITLE
Fix bug in TryMapVirtualAddressToRaw

### DIFF
--- a/LibCpp2IL/Il2CppBinary.cs
+++ b/LibCpp2IL/Il2CppBinary.cs
@@ -348,7 +348,8 @@ public abstract class Il2CppBinary(MemoryStream input) : ClassReadingBinaryReade
     {
         result = MapVirtualAddressToRaw(virtAddr, false);
 
-        if (result != VirtToRawInvalidNoMatch)
+        // Negative results indicate error codes
+        if (result >= 0)
             return true;
 
         result = 0;

--- a/LibCpp2IL/PE/PE.cs
+++ b/LibCpp2IL/PE/PE.cs
@@ -99,7 +99,13 @@ public sealed class PE : Il2CppBinary
 
         var section = peSectionHeaders.FirstOrDefault(x => addr >= x.VirtualAddress && addr < x.VirtualAddress + x.VirtualSize);
 
-        if (section == null) return 0L;
+        if (section == null)
+        {
+            if (throwOnError)
+                throw new ArgumentOutOfRangeException(nameof(uiAddr), $"Provided address maps to image offset 0x{addr:X} which is outside the range of every section in the file");
+
+            return VirtToRawInvalidOutOfBounds;
+        }
 
         return addr - (section.VirtualAddress - section.PointerToRawData);
     }


### PR DESCRIPTION
Previously, it could return true with invalid output because only one error code was being checked.

This also fixes the behavior in PE::MapVirtualAddressToRaw for when no section is found.