### PR TITLE
Add NuGet packaging metadata and publish workflow for plugin projects

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release-net9:
-    strategy:     
+    strategy:
       matrix:
         runtimeIdentifier: [linux-x64, linux-arm64, osx-x64, osx-arm64, win-x64, win-arm64]
         project: [Cpp2IL]
@@ -31,9 +31,9 @@ jobs:
         with:
           script: |
             core.setOutput("extension", "${{ matrix.runtimeIdentifier }}" === "win-x64" ? ".exe" : "");
-            
+
             let gitHash = "${{ steps.git-vars.outputs.git_hash }}";
-            let runNumber = "${{ github.run_number }}"; 
+            let runNumber = "${{ github.run_number }}";
             let rawGitRef = "${{ steps.git-vars.outputs.git_branch }}";
             console.log("rawGitRef: " + rawGitRef);
             let gitRef = rawGitRef.replace(/^refs\/heads\//, "");
@@ -91,7 +91,7 @@ jobs:
         with:
           script: |
             let gitHash = "${{ steps.git-vars.outputs.git_hash }}";
-            let runNumber = "${{ github.run_number }}"; 
+            let runNumber = "${{ github.run_number }}";
             let rawGitRef = "${{ steps.git-vars.outputs.git_branch }}";
             console.log("rawGitRef: " + rawGitRef);
             let gitRef = rawGitRef.replace(/^refs\/heads\//, "");
@@ -124,4 +124,19 @@ jobs:
       - name: Publish Cpp2IL.Core
         if: github.event_name == 'push'
         run: dotnet nuget push -s https://nuget.samboy.dev/v3/index.json -k ${{ secrets.NUGET_KEY }} ./Cpp2IL.Core/bin/Release/*.nupkg
-      
+      - name: Publish Cpp2IL.Plugin.BuildReport
+        if: github.event_name == 'push'
+        run: dotnet nuget push -s https://nuget.samboy.dev/v3/index.json -k ${{ secrets.NUGET_KEY }} ./Cpp2IL.Plugin.BuildReport/bin/Release/*.nupkg
+      - name: Publish Cpp2IL.Plugin.ControlFlowGraph
+        if: github.event_name == 'push'
+        run: dotnet nuget push -s https://nuget.samboy.dev/v3/index.json -k ${{ secrets.NUGET_KEY }} ./Cpp2IL.Plugin.ControlFlowGraph/bin/Release/*.nupkg
+      - name: Publish Cpp2IL.Plugin.OrbisPkg
+        if: github.event_name == 'push'
+        run: dotnet nuget push -s https://nuget.samboy.dev/v3/index.json -k ${{ secrets.NUGET_KEY }} ./Cpp2IL.Plugin.OrbisPkg/bin/Release/*.nupkg
+      - name: Publish Cpp2IL.Plugin.Pdb
+        if: github.event_name == 'push'
+        run: dotnet nuget push -s https://nuget.samboy.dev/v3/index.json -k ${{ secrets.NUGET_KEY }} ./Cpp2IL.Plugin.Pdb/bin/Release/*.nupkg
+      - name: Publish Cpp2IL.Plugin.StrippedCodeRegSupport
+        if: github.event_name == 'push'
+        run: dotnet nuget push -s https://nuget.samboy.dev/v3/index.json -k ${{ secrets.NUGET_KEY }} ./Cpp2IL.Plugin.StrippedCodeRegSupport/bin/Release/*.nupkg
+

--- a/Cpp2IL.Plugin.BuildReport/Cpp2IL.Plugin.BuildReport.csproj
+++ b/Cpp2IL.Plugin.BuildReport/Cpp2IL.Plugin.BuildReport.csproj
@@ -7,6 +7,20 @@
         <DebugType>embedded</DebugType>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <Authors>Sam Byass (Samboy063)</Authors>
+        <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+        <Copyright>Copyright © Samboy063 2022-2025</Copyright>
+        <Description>Plugin for Cpp2IL</Description>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>Samboy063.$(MSBuildProjectName)</PackageId>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/SamboyCoding/Cpp2IL</PackageProjectUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <Title>$(MSBuildProjectName)</Title>
+        <VersionPrefix>2022.1.0</VersionPrefix>
+    </PropertyGroup>
+
     <ItemGroup>
       <ProjectReference Include="..\Cpp2IL.Core\Cpp2IL.Core.csproj">
           <PrivateAssets>all</PrivateAssets>
@@ -17,6 +31,7 @@
 
     <ItemGroup>
       <PackageReference Include="System.Text.Json" Version="10.0.1" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.200" PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/Cpp2IL.Plugin.ControlFlowGraph/Cpp2IL.Plugin.ControlFlowGraph.csproj
+++ b/Cpp2IL.Plugin.ControlFlowGraph/Cpp2IL.Plugin.ControlFlowGraph.csproj
@@ -10,6 +10,20 @@
         <GenerateDependencyFile>false</GenerateDependencyFile>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <Authors>Sam Byass (Samboy063)</Authors>
+        <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+        <Copyright>Copyright © Samboy063 2024-2025</Copyright>
+        <Description>Plugin for Cpp2IL</Description>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>Samboy063.$(MSBuildProjectName)</PackageId>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/SamboyCoding/Cpp2IL</PackageProjectUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <Title>$(MSBuildProjectName)</Title>
+        <VersionPrefix>2022.1.0</VersionPrefix>
+    </PropertyGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\Cpp2IL.Core\Cpp2IL.Core.csproj" ExcludeAssets="All" Private="false"/>
 		<ProjectReference Include="..\LibCpp2IL\LibCpp2IL.csproj" ExcludeAssets="All" Private="false"/>
@@ -17,6 +31,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="DotNetGraph" Version="3.3.0" IncludeAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.200" PrivateAssets="All" />
 	</ItemGroup>
 
 </Project>

--- a/Cpp2IL.Plugin.OrbisPkg/Cpp2IL.Plugin.OrbisPkg.csproj
+++ b/Cpp2IL.Plugin.OrbisPkg/Cpp2IL.Plugin.OrbisPkg.csproj
@@ -8,6 +8,24 @@
         <DebugType>embedded</DebugType>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <Authors>Sam Byass (Samboy063)</Authors>
+        <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+        <Copyright>Copyright © Samboy063 2022-2024</Copyright>
+        <Description>Plugin for Cpp2IL</Description>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>Samboy063.$(MSBuildProjectName)</PackageId>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/SamboyCoding/Cpp2IL</PackageProjectUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <Title>$(MSBuildProjectName)</Title>
+        <VersionPrefix>2022.1.0</VersionPrefix>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.200" PrivateAssets="All" />
+    </ItemGroup>
+
     <ItemGroup>
       <ProjectReference Include="..\Cpp2IL.Core\Cpp2IL.Core.csproj" />
     </ItemGroup>

--- a/Cpp2IL.Plugin.Pdb/Cpp2IL.Plugin.Pdb.csproj
+++ b/Cpp2IL.Plugin.Pdb/Cpp2IL.Plugin.Pdb.csproj
@@ -5,7 +5,26 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <DebugType>embedded</DebugType>
     </PropertyGroup>
+
+    <PropertyGroup>
+        <Authors>Sam Byass (Samboy063)</Authors>
+        <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+        <Copyright>Copyright © Samboy063 2024</Copyright>
+        <Description>Plugin for Cpp2IL</Description>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>Samboy063.$(MSBuildProjectName)</PackageId>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/SamboyCoding/Cpp2IL</PackageProjectUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <Title>$(MSBuildProjectName)</Title>
+        <VersionPrefix>2022.1.0</VersionPrefix>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.200" PrivateAssets="All" />
+    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Cpp2IL.Core\Cpp2IL.Core.csproj" />

--- a/Cpp2IL.Plugin.StrippedCodeRegSupport/Cpp2IL.Plugin.StrippedCodeRegSupport.csproj
+++ b/Cpp2IL.Plugin.StrippedCodeRegSupport/Cpp2IL.Plugin.StrippedCodeRegSupport.csproj
@@ -4,8 +4,27 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <DebugType>embedded</DebugType>
     </PropertyGroup>
-
+  
+    <PropertyGroup>
+        <Authors>Sam Byass (Samboy063)</Authors>
+        <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+        <Copyright>Copyright © Samboy063 2023-2026</Copyright>
+        <Description>Plugin for Cpp2IL</Description>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>Samboy063.$(MSBuildProjectName)</PackageId>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/SamboyCoding/Cpp2IL</PackageProjectUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <Title>$(MSBuildProjectName)</Title>
+        <VersionPrefix>2022.1.0</VersionPrefix>
+    </PropertyGroup>
+  
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.200" PrivateAssets="All" />
+    </ItemGroup>
+  
     <ItemGroup>
       <ProjectReference Include="..\Cpp2IL.Core\Cpp2IL.Core.csproj" />
     </ItemGroup>

--- a/LibCpp2IL/LibCpp2IL.csproj
+++ b/LibCpp2IL/LibCpp2IL.csproj
@@ -19,6 +19,7 @@
         <Configurations>Debug;Release</Configurations>
         <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
         <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+        <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
     </PropertyGroup>
 
     <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">


### PR DESCRIPTION
Add package metadata and SourceLink to plugin projects. Update CI workflow to add publish steps for each plugin NuGet package. Also set ContinuousIntegrationBuild in LibCpp2IL to ensure CI-specific packaging behaviour.