### PR TITLE
Fix diffable-cs throwing ArgumentOutOfRangeException

### DIFF
--- a/Cpp2IL.Core/Model/Contexts/ParameterAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/ParameterAnalysisContext.cs
@@ -102,7 +102,7 @@ public class ParameterAnalysisContext : HasCustomAttributesAndName, IParameterIn
         else if (ParameterType is ByRefTypeAnalysisContext)
             result.Append("ref ");
 
-        result.Append(CsFileUtils.GetTypeName(ParameterType.Name)).Append(' ');
+        result.Append(CsFileUtils.GetTypeName(ParameterType)).Append(' ');
 
         if (string.IsNullOrEmpty(ParameterName))
             result.Append("unnamed_param_").Append(ParameterIndex);

--- a/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
+++ b/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
@@ -95,7 +95,7 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
 
         sb.Append(CsFileUtils.GetKeyWordsForType(type));
         sb.Append(' ');
-        sb.Append(CsFileUtils.GetTypeName(type.Name));
+        sb.Append(CsFileUtils.GetTypeName(type));
         CsFileUtils.AppendInheritanceInfo(type, sb);
         sb.AppendLine();
         sb.Append('\t', indent);
@@ -173,7 +173,7 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         sb.Append('\t', indent);
         sb.Append(CsFileUtils.GetKeyWordsForField(field));
         sb.Append(' ');
-        sb.Append(CsFileUtils.GetTypeName(field.FieldType.Name));
+        sb.Append(CsFileUtils.GetTypeName(field.FieldType));
         sb.Append(' ');
         sb.Append(field.Name);
 
@@ -226,7 +226,7 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         sb.Append('\t', indent);
         sb.Append(CsFileUtils.GetKeyWordsForEvent(evt));
         sb.Append(' ');
-        sb.Append(CsFileUtils.GetTypeName(evt.EventType.Name));
+        sb.Append(CsFileUtils.GetTypeName(evt.EventType));
         sb.Append(' ');
         sb.Append(evt.Name).AppendLine();
         sb.Append('\t', indent);
@@ -257,7 +257,7 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         sb.Append('\t', indent);
         sb.Append(CsFileUtils.GetKeyWordsForProperty(prop));
         sb.Append(' ');
-        sb.Append(CsFileUtils.GetTypeName(prop.PropertyType.Name));
+        sb.Append(CsFileUtils.GetTypeName(prop.PropertyType));
         sb.Append(' ');
         sb.Append(prop.Name);
         sb.AppendLine();
@@ -292,14 +292,14 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         sb.Append(' ');
         if (method.Name is not ".ctor" and not ".cctor")
         {
-            sb.Append(CsFileUtils.GetTypeName(method.ReturnType.Name));
+            sb.Append(CsFileUtils.GetTypeName(method.ReturnType));
             sb.Append(' ');
             sb.Append(method.Name);
         }
         else
         {
             //Constructor
-            sb.Append(method.DeclaringType!.Name);
+            sb.Append(method.DeclaringType!);
         }
 
         sb.Append('(');

--- a/Cpp2IL.Core/Utils/CsFileUtils.cs
+++ b/Cpp2IL.Core/Utils/CsFileUtils.cs
@@ -308,7 +308,7 @@ public static class CsFileUtils
         if (type is GenericInstanceTypeAnalysisContext genericInstanceType)
         {
             var genericTypeName = GetTypeName(genericInstanceType.GenericType);
-            var backTickIndex = genericTypeName.IndexOf('`');
+            var backTickIndex = genericTypeName.LastIndexOf('`');
             return backTickIndex > 0 ? genericTypeName[..backTickIndex] : genericTypeName;
         }
 

--- a/Cpp2IL.Core/Utils/CsFileUtils.cs
+++ b/Cpp2IL.Core/Utils/CsFileUtils.cs
@@ -276,36 +276,69 @@ public static class CsFileUtils
     /// Returns the name of the given type, as it would appear in a C# source file.
     /// This mainly involves stripping the backtick section from generic type names, and replacing certain system types with their primitive name.
     /// </summary>
-    /// <param name="originalName">The original name of the type</param>
-    public static string GetTypeName(string originalName)
+    /// <param name="type"></param>
+    public static string GetTypeName(TypeAnalysisContext type)
     {
-        if (originalName.Contains("`"))
-            //Generics - remove `1 etc
-            return originalName.Remove(originalName.IndexOf('`'), 2);
-
-        if (originalName[^1] == '&')
-            originalName = originalName[..^1]; //Remove trailing & for ref params
-
-        return originalName switch
+        if (type is WrappedTypeAnalysisContext wrapped)
         {
-            "Void" => "void",
-            "Boolean" => "bool",
-            "Byte" => "byte",
-            "SByte" => "sbyte",
-            "Char" => "char",
-            "Decimal" => "decimal",
-            "Single" => "float",
-            "Double" => "double",
-            "Int32" => "int",
-            "UInt32" => "uint",
-            "Int64" => "long",
-            "UInt64" => "ulong",
-            "Int16" => "short",
-            "UInt16" => "ushort",
-            "String" => "string",
-            "Object" => "object",
-            _ => originalName
-        };
+            var elementTypeName = GetTypeName(wrapped.ElementType);
+            switch (wrapped)
+            {
+                case ArrayTypeAnalysisContext arrayType:
+                    {
+                        return arrayType.Rank switch
+                        {
+                            1 => elementTypeName + "[]",
+                            2 => elementTypeName + "[,]",
+                            3 => elementTypeName + "[,,]",
+                            _ => elementTypeName + "[" + new string(',', arrayType.Rank - 1) + "]"
+                        };
+                    }
+                case SzArrayTypeAnalysisContext:
+                    return elementTypeName + "[]";
+                case PointerTypeAnalysisContext:
+                    return elementTypeName + "*";
+                case ByRefTypeAnalysisContext:
+                    return elementTypeName; //Remove trailing & for ref params
+                default:
+                    return elementTypeName;
+            }
+        }
+
+        if (type is GenericInstanceTypeAnalysisContext genericInstanceType)
+        {
+            var genericTypeName = GetTypeName(genericInstanceType.GenericType);
+            var backTickIndex = genericTypeName.IndexOf('`');
+            return backTickIndex > 0 ? genericTypeName[..backTickIndex] : genericTypeName;
+        }
+
+        if (type.Namespace is "System")
+        {
+            return type.Name switch
+            {
+                "Void" => "void",
+                "Boolean" => "bool",
+                "Byte" => "byte",
+                "SByte" => "sbyte",
+                "Char" => "char",
+                "Decimal" => "decimal",
+                "Single" => "float",
+                "Double" => "double",
+                "Int32" => "int",
+                "UInt32" => "uint",
+                "Int64" => "long",
+                "UInt64" => "ulong",
+                "Int16" => "short",
+                "UInt16" => "ushort",
+                "String" => "string",
+                "Object" => "object",
+                _ => type.Name,
+            };
+        }
+        else
+        {
+            return type.Name;
+        }
     }
 
     /// <summary>
@@ -319,7 +352,7 @@ public static class CsFileUtils
         var baseType = type.BaseType;
         var needsBaseClass = baseType is { FullName: not "System.Object" and not "System.ValueType" and not "System.Enum" };
         if (needsBaseClass)
-            sb.Append(" : ").Append(GetTypeName(baseType!.Name));
+            sb.Append(" : ").Append(GetTypeName(baseType!));
 
         //Interfaces
         if (type.InterfaceContexts.Count <= 0)
@@ -336,7 +369,7 @@ public static class CsFileUtils
 
             addComma = true;
 
-            sb.Append(GetTypeName(iface.Name));
+            sb.Append(GetTypeName(iface));
         }
     }
 }


### PR DESCRIPTION
Resolves #534 

It also makes the implementation a little more robust:

* Generics with more than 9 parameters are supported.
* We now verify that a type is in the System namespace before returning a primitive type name.
* We now support arrays of primitives.