### PR TITLE
Handle properties with no accessors

### DIFF
--- a/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
@@ -278,7 +278,13 @@ public static class AsmResolverAssemblyPopulator
                     CopyCustomAttributes(field, field.GetExtraData<FieldDefinition>("AsmResolverField")!.CustomAttributes);
 
                 foreach (var property in type.Properties)
-                    CopyCustomAttributes(property, property.GetExtraData<PropertyDefinition>("AsmResolverProperty")!.CustomAttributes);
+                {
+                    // Property may have been skipped in CopyPropertiesInType (e.g. badly stripped metadata can lead to
+                    // properties with no accessors). Skip custom attribute copy too.
+                    var propertyDef = property.GetExtraData<PropertyDefinition>("AsmResolverProperty");
+                    if (propertyDef == null) continue;
+                    CopyCustomAttributes(property, propertyDef.CustomAttributes);
+                }
 
                 foreach (var eventDefinition in type.Events)
                     CopyCustomAttributes(eventDefinition, eventDefinition.GetExtraData<EventDefinition>("AsmResolverEvent")!.CustomAttributes);
@@ -443,6 +449,10 @@ public static class AsmResolverAssemblyPopulator
     {
         foreach (var propertyCtx in typeContext.Properties)
         {
+            // Skip bad properties with neither getter nor setter — their type can't be resolved.
+            if (propertyCtx.Getter == null && propertyCtx.Setter == null)
+                continue;
+
             var propertyTypeSig = propertyCtx.ToTypeSignature(importer.TargetModule);
             var propertySignature = propertyCtx.IsStatic
                 ? PropertySignature.CreateStatic(propertyTypeSig)

--- a/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
@@ -449,7 +449,7 @@ public static class AsmResolverAssemblyPopulator
     {
         foreach (var propertyCtx in typeContext.Properties)
         {
-            // Skip bad properties with neither getter nor setter — their type can't be resolved.
+            // Skip properties whose getter and setter were both stripped.
             if (propertyCtx.Getter == null && propertyCtx.Setter == null)
                 continue;
 

--- a/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
@@ -279,8 +279,8 @@ public static class AsmResolverAssemblyPopulator
 
                 foreach (var property in type.Properties)
                 {
-                    // Property may have been skipped in CopyPropertiesInType (e.g. badly stripped metadata can lead to
-                    // properties with no accessors). Skip custom attribute copy too.
+                    // Property with no accessors are skipped in CopyPropertiesInType.
+                    // Skip copying custom attributes, too.
                     var propertyDef = property.GetExtraData<PropertyDefinition>("AsmResolverProperty");
                     if (propertyDef == null) continue;
                     CopyCustomAttributes(property, propertyDef.CustomAttributes);

--- a/LibCpp2IL/Metadata/Il2CppPropertyDefinition.cs
+++ b/LibCpp2IL/Metadata/Il2CppPropertyDefinition.cs
@@ -56,7 +56,7 @@ public class Il2CppPropertyDefinition : ReadableClass, IIl2CppTokenProvider
         {
             if (LibCpp2IlMain.TheMetadata == null) return null;
             if (Getter != null) return Getter.RawReturnType;
-            if (Setter != null && Setter.Parameters is { Length: > 0 }) return Setter.Parameters[0].RawType;
+            if (Setter != null && Setter.Parameters is { Length: > 0 }) return Setter.Parameters[^1].RawType;
             return null;
         }
     }

--- a/LibCpp2IL/Metadata/Il2CppPropertyDefinition.cs
+++ b/LibCpp2IL/Metadata/Il2CppPropertyDefinition.cs
@@ -45,7 +45,7 @@ public class Il2CppPropertyDefinition : ReadableClass, IIl2CppTokenProvider
         {
             if (LibCpp2IlMain.TheMetadata == null) return null;
             if (Getter != null) return Getter.ReturnType;
-            if (Setter != null && Setter.Parameters is { Length: > 0 }) return Setter.Parameters[0].Type;
+            if (Setter != null && Setter.Parameters is { Length: > 0 }) return Setter.Parameters[^1].Type;
             return null;
         }
     }

--- a/LibCpp2IL/Metadata/Il2CppPropertyDefinition.cs
+++ b/LibCpp2IL/Metadata/Il2CppPropertyDefinition.cs
@@ -39,11 +39,29 @@ public class Il2CppPropertyDefinition : ReadableClass, IIl2CppTokenProvider
 
     public Il2CppMethodDefinition? Setter => LibCpp2IlMain.TheMetadata == null || set.IsNull || DeclaringType == null ? null : LibCpp2IlMain.TheMetadata.GetMethodDefinitionFromIndex(DeclaringType.FirstMethodIdx + set);
 
-    public Il2CppTypeReflectionData? PropertyType => LibCpp2IlMain.TheMetadata == null ? null : Getter == null ? Setter!.Parameters![0].Type : Getter!.ReturnType;
+    public Il2CppTypeReflectionData? PropertyType
+    {
+        get
+        {
+            if (LibCpp2IlMain.TheMetadata == null) return null;
+            if (Getter != null) return Getter.ReturnType;
+            if (Setter != null && Setter.Parameters is { Length: > 0 }) return Setter.Parameters[0].Type;
+            return null;
+        }
+    }
 
-    public Il2CppType? RawPropertyType => LibCpp2IlMain.TheMetadata == null ? null : Getter == null ? Setter!.Parameters![0].RawType : Getter!.RawReturnType;
+    public Il2CppType? RawPropertyType
+    {
+        get
+        {
+            if (LibCpp2IlMain.TheMetadata == null) return null;
+            if (Getter != null) return Getter.RawReturnType;
+            if (Setter != null && Setter.Parameters is { Length: > 0 }) return Setter.Parameters[0].RawType;
+            return null;
+        }
+    }
 
-    public bool IsStatic => Getter == null ? Setter!.IsStatic : Getter!.IsStatic;
+    public bool IsStatic => Getter?.IsStatic ?? Setter?.IsStatic ?? false;
     public uint Token => token;
 
     public override void Read(ClassReadingBinaryReader reader)


### PR DESCRIPTION
Some IL2CPP metadata contains properties whose getter and setter have both been stripped completely.

Il2CppPropertyDefinition.PropertyType / RawPropertyType derived their result solely from the accessor signatures and dereferenced the setter with null-forgiving operators, NREing when both were null.

Reproduced on Relic Arena (Unity 6000.3.14f1) where ZstdSharp.Unsafe.Methods contains a bad property, crashing CopyPropertiesInType and failing afterwards.

- Il2CppPropertyDefinition: PropertyType, RawPropertyType, and IsStatic now return null / false instead of NRE when both accessors are missing.
- AsmResolverAssemblyPopulator.CopyPropertiesInType: skip properties with no accessors
- AsmResolverAssemblyPopulator.PopulateCustomAttributes: skip properties that were skipped above