### PR TITLE
Support null Definition for CustomAttributeIndex

### DIFF
--- a/Cpp2IL.Core/Model/Contexts/ReferencedTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/ReferencedTypeAnalysisContext.cs
@@ -11,10 +11,6 @@ public abstract class ReferencedTypeAnalysisContext(AssemblyAnalysisContext refe
 {
     public override Il2CppTypeEnum Type => throw new NotImplementedException("Type must be set by derived classes");
 
-    protected override int CustomAttributeIndex => -1;
-
-    public override AssemblyAnalysisContext CustomAttributeAssembly => DeclaringAssembly;
-
     public override string ToString()
     {
         return DefaultName;

--- a/Cpp2IL.Core/Model/Contexts/TypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/TypeAnalysisContext.cs
@@ -53,7 +53,7 @@ public class TypeAnalysisContext : HasGenericParameters, ITypeInfoProvider, ICSh
     /// </summary>
     public List<TypeAnalysisContext> NestedTypes { get; internal set; } = [];
 
-    protected override int CustomAttributeIndex => Definition!.CustomAttributeIndex;
+    protected override int CustomAttributeIndex => Definition?.CustomAttributeIndex ?? -1;
 
     public override AssemblyAnalysisContext CustomAttributeAssembly => DeclaringAssembly;
 


### PR DESCRIPTION
* Added null branch for Definition, so that it doesn't throw for InjectedTypeAnalysisContext
* Removed redundant overrides in ReferencedTypeAnalysisContext