### PR TITLE
Fix name overrides for constructed types

### DIFF
--- a/Cpp2IL.Core/Model/Contexts/ArrayTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/ArrayTypeAnalysisContext.cs
@@ -1,3 +1,4 @@
+using System;
 using Cpp2IL.Core.Utils;
 using LibCpp2IL.BinaryStructures;
 
@@ -11,9 +12,15 @@ public class ArrayTypeAnalysisContext(TypeAnalysisContext elementType, int rank,
     {
     }
 
-    public override Il2CppTypeEnum Type => Il2CppTypeEnum.IL2CPP_TYPE_ARRAY;
+    public sealed override Il2CppTypeEnum Type => Il2CppTypeEnum.IL2CPP_TYPE_ARRAY;
 
-    public override string DefaultName => $"{ElementType.Name}[{Rank}]";
+    public sealed override string DefaultName => $"{ElementType.DefaultName}[{Rank}]";
+
+    public sealed override string? OverrideName
+    {
+        get => $"{ElementType.Name}[{Rank}]";
+        set => throw new NotSupportedException();
+    }
 
     public sealed override bool IsValueType => false;
 

--- a/Cpp2IL.Core/Model/Contexts/BoxedTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/BoxedTypeAnalysisContext.cs
@@ -11,9 +11,15 @@ public class BoxedTypeAnalysisContext(TypeAnalysisContext elementType, AssemblyA
     {
     }
 
-    public override Il2CppTypeEnum Type => Il2CppTypeEnum.IL2CPP_TYPE_BOXED;
+    public sealed override Il2CppTypeEnum Type => Il2CppTypeEnum.IL2CPP_TYPE_BOXED;
 
-    public override string DefaultName => ElementType.Name;
+    public sealed override string DefaultName => ElementType.DefaultName;
+
+    public sealed override string? OverrideName
+    {
+        get => ElementType.OverrideName;
+        set => ElementType.OverrideName = value;
+    }
 
     public sealed override bool IsValueType => false;
 }

--- a/Cpp2IL.Core/Model/Contexts/ByRefTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/ByRefTypeAnalysisContext.cs
@@ -1,3 +1,4 @@
+using System;
 using LibCpp2IL.BinaryStructures;
 
 namespace Cpp2IL.Core.Model.Contexts;
@@ -10,9 +11,15 @@ public class ByRefTypeAnalysisContext(TypeAnalysisContext elementType, AssemblyA
     {
     }
 
-    public override Il2CppTypeEnum Type => Il2CppTypeEnum.IL2CPP_TYPE_BYREF;
+    public sealed override Il2CppTypeEnum Type => Il2CppTypeEnum.IL2CPP_TYPE_BYREF;
 
-    public override string DefaultName => $"{ElementType.Name}&";
+    public sealed override string DefaultName => $"{ElementType.DefaultName}&";
+
+    public sealed override string? OverrideName
+    {
+        get => $"{ElementType.Name}&";
+        set => throw new NotSupportedException();
+    }
 
     public sealed override bool IsValueType => false;
 

--- a/Cpp2IL.Core/Model/Contexts/CustomModifierTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/CustomModifierTypeAnalysisContext.cs
@@ -1,3 +1,4 @@
+using System;
 using LibCpp2IL.BinaryStructures;
 
 namespace Cpp2IL.Core.Model.Contexts;
@@ -9,11 +10,19 @@ public class CustomModifierTypeAnalysisContext(TypeAnalysisContext elementType, 
 
     public bool Required { get; } = required;
 
-    public override Il2CppTypeEnum Type => Required ? Il2CppTypeEnum.IL2CPP_TYPE_CMOD_REQD : Il2CppTypeEnum.IL2CPP_TYPE_CMOD_OPT;
+    public sealed override Il2CppTypeEnum Type => Required ? Il2CppTypeEnum.IL2CPP_TYPE_CMOD_REQD : Il2CppTypeEnum.IL2CPP_TYPE_CMOD_OPT;
 
-    public override string DefaultName => Required
-        ? $"{ElementType.Name} modreq({ModifierType.Name})"
-        : $"{ElementType.Name} modopt({ModifierType.Name})";
+    public sealed override string DefaultName => Required
+        ? $"{ElementType.DefaultName} modreq({ModifierType.DefaultFullName})"
+        : $"{ElementType.DefaultName} modopt({ModifierType.DefaultFullName})";
+
+    public sealed override string? OverrideName
+    {
+        get => Required
+            ? $"{ElementType.Name} modreq({ModifierType.FullName})"
+            : $"{ElementType.Name} modopt({ModifierType.FullName})";
+        set => throw new NotSupportedException();
+    }
 
     public sealed override bool IsValueType => ElementType.IsValueType;
 }

--- a/Cpp2IL.Core/Model/Contexts/GenericInstanceTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/GenericInstanceTypeAnalysisContext.cs
@@ -15,15 +15,27 @@ public class GenericInstanceTypeAnalysisContext : ReferencedTypeAnalysisContext
 
     public List<TypeAnalysisContext> GenericArguments { get; } = [];
 
-    public override TypeAttributes DefaultAttributes => GenericType.DefaultAttributes;
+    public sealed override TypeAttributes DefaultAttributes => GenericType.DefaultAttributes;
 
-    public override TypeAttributes? OverrideAttributes { get => GenericType.OverrideAttributes; set => GenericType.OverrideAttributes = value; }
+    public sealed override TypeAttributes? OverrideAttributes { get => GenericType.OverrideAttributes; set => GenericType.OverrideAttributes = value; }
 
-    public override string DefaultName => $"{GenericType.Name}<{string.Join(", ", GenericArguments.Select(a => a.Name))}>";
+    public sealed override string DefaultName => $"{GenericType.DefaultName}<{string.Join(", ", GenericArguments.Select(a => a.DefaultFullName))}>";
 
-    public override string DefaultNamespace => GenericType.Namespace;
+    public sealed override string? OverrideName
+    {
+        get => $"{GenericType.Name}<{string.Join(", ", GenericArguments.Select(a => a.FullName))}>";
+        set => throw new NotSupportedException();
+    }
 
-    public override TypeAnalysisContext? DefaultBaseType { get; }
+    public sealed override string DefaultNamespace => GenericType.DefaultNamespace;
+
+    public sealed override string? OverrideNamespace
+    {
+        get => GenericType.OverrideNamespace;
+        set => GenericType.OverrideNamespace = value;
+    }
+
+    public sealed override TypeAnalysisContext? DefaultBaseType { get; }
 
     public sealed override Il2CppTypeEnum Type => Il2CppTypeEnum.IL2CPP_TYPE_GENERICINST;
 

--- a/Cpp2IL.Core/Model/Contexts/GenericParameterTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/GenericParameterTypeAnalysisContext.cs
@@ -16,9 +16,17 @@ public class GenericParameterTypeAnalysisContext : ReferencedTypeAnalysisContext
 
     public sealed override string DefaultNamespace => "";
 
+    public sealed override string? OverrideNamespace
+    {
+        get => null;
+        set
+        {
+        }
+    }
+
     public int Index { get; }
 
-    public override Il2CppTypeEnum Type { get; }
+    public sealed override Il2CppTypeEnum Type { get; }
 
     public new GenericParameterAttributes DefaultAttributes { get; }
     public new GenericParameterAttributes? OverrideAttributes { get; set; }

--- a/Cpp2IL.Core/Model/Contexts/PinnedTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/PinnedTypeAnalysisContext.cs
@@ -11,9 +11,15 @@ public class PinnedTypeAnalysisContext(TypeAnalysisContext elementType, Assembly
     {
     }
 
-    public override Il2CppTypeEnum Type => Il2CppTypeEnum.IL2CPP_TYPE_PINNED;
+    public sealed override Il2CppTypeEnum Type => Il2CppTypeEnum.IL2CPP_TYPE_PINNED;
 
-    public override string DefaultName => ElementType.Name;
+    public sealed override string DefaultName => ElementType.DefaultName;
+
+    public sealed override string? OverrideName
+    {
+        get => ElementType.OverrideName;
+        set => ElementType.OverrideName = value;
+    }
 
     public sealed override bool IsValueType => false;
 }

--- a/Cpp2IL.Core/Model/Contexts/PointerTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/PointerTypeAnalysisContext.cs
@@ -1,3 +1,4 @@
+using System;
 using Cpp2IL.Core.Utils;
 using LibCpp2IL.BinaryStructures;
 
@@ -11,9 +12,15 @@ public class PointerTypeAnalysisContext(TypeAnalysisContext elementType, Assembl
     {
     }
 
-    public override Il2CppTypeEnum Type => Il2CppTypeEnum.IL2CPP_TYPE_PTR;
+    public sealed override Il2CppTypeEnum Type => Il2CppTypeEnum.IL2CPP_TYPE_PTR;
 
-    public override string DefaultName => $"{ElementType.Name}*";
+    public sealed override string DefaultName => $"{ElementType.DefaultName}*";
+
+    public sealed override string? OverrideName
+    {
+        get => $"{ElementType.Name}*";
+        set => throw new NotSupportedException();
+    }
 
     public sealed override bool IsValueType => false;
 }

--- a/Cpp2IL.Core/Model/Contexts/ReferencedTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/ReferencedTypeAnalysisContext.cs
@@ -11,11 +11,6 @@ public abstract class ReferencedTypeAnalysisContext(AssemblyAnalysisContext refe
 {
     public override Il2CppTypeEnum Type => throw new NotImplementedException("Type must be set by derived classes");
 
-    public override string ToString()
-    {
-        return DefaultName;
-    }
-
     public override string GetCSharpSourceString()
     {
         return Name;

--- a/Cpp2IL.Core/Model/Contexts/SentinelTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/SentinelTypeAnalysisContext.cs
@@ -6,5 +6,20 @@ public sealed class SentinelTypeAnalysisContext(AssemblyAnalysisContext referenc
 {
     public override Il2CppTypeEnum Type => Il2CppTypeEnum.IL2CPP_TYPE_SENTINEL;
     public override string DefaultName => "<<SENTINEL>>";
+    public override string? OverrideName
+    {
+        get => null;
+        set
+        {
+        }
+    }
+    public override string DefaultNamespace => "";
+    public override string? OverrideNamespace
+    {
+        get => null;
+        set
+        {
+        }
+    }
     public override bool IsValueType => false;
 }

--- a/Cpp2IL.Core/Model/Contexts/SzArrayTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/SzArrayTypeAnalysisContext.cs
@@ -1,3 +1,4 @@
+using System;
 using Cpp2IL.Core.Utils;
 using LibCpp2IL.BinaryStructures;
 
@@ -11,9 +12,15 @@ public class SzArrayTypeAnalysisContext(TypeAnalysisContext elementType, Assembl
     {
     }
 
-    public override Il2CppTypeEnum Type => Il2CppTypeEnum.IL2CPP_TYPE_SZARRAY;
+    public sealed override Il2CppTypeEnum Type => Il2CppTypeEnum.IL2CPP_TYPE_SZARRAY;
 
-    public override string DefaultName => $"{ElementType.Name}[]";
+    public sealed override string DefaultName => $"{ElementType.DefaultName}[]";
+
+    public sealed override string? OverrideName
+    {
+        get => $"{ElementType.Name}[]";
+        set => throw new NotSupportedException();
+    }
 
     public sealed override bool IsValueType => false;
 }

--- a/Cpp2IL.Core/Model/Contexts/TypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/TypeAnalysisContext.cs
@@ -60,7 +60,7 @@ public class TypeAnalysisContext : HasGenericParameters, ITypeInfoProvider
 
     public virtual string DefaultNamespace => Definition?.Namespace ?? throw new("Subclasses of TypeAnalysisContext must override DefaultNs");
 
-    public string? OverrideNamespace { get; set; }
+    public virtual string? OverrideNamespace { get; set; }
 
     public string Namespace
     {

--- a/Cpp2IL.Core/Model/Contexts/WrappedTypeAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/WrappedTypeAnalysisContext.cs
@@ -12,7 +12,13 @@ public abstract class WrappedTypeAnalysisContext(
 {
     public virtual TypeAnalysisContext ElementType { get; } = elementType;
 
-    public override string DefaultNamespace => ElementType.Namespace;
+    public sealed override string DefaultNamespace => ElementType.DefaultNamespace;
+
+    public sealed override string? OverrideNamespace
+    {
+        get => ElementType.OverrideNamespace;
+        set => ElementType.OverrideNamespace = value;
+    }
 
     public static WrappedTypeAnalysisContext Create(Il2CppType rawType, AssemblyAnalysisContext referencedFrom)
     {


### PR DESCRIPTION
* Ensure that DefaultName only calls DefaultName and DefaultFullName, not Name or FullName
* Remove unnecessary ReferenceTypeAnalysisContext::ToString override
* Seal Type and name properties
* Use DefaultFullName and FullName for arguments of GenericInstanceTypeAnalysisContext to ensure expected output from its own DefaultFullName and FullName