### PR TITLE
Improve ARMv8 function calling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ obj/
 launchsettings.json
 
 artifacts/
+
+.DS_Store

--- a/Cpp2IL.Core/IlGenerator.cs
+++ b/Cpp2IL.Core/IlGenerator.cs
@@ -219,7 +219,8 @@ public static class IlGenerator
                 }
 
                 // Load normal params
-                var callParams = instruction.Operands.Skip(thisParamIndex + (targetMethod.IsStatic ? 0 : -1));
+                var callParamIndex = instruction.OpCode == OpCode.Call ? (targetMethod.IsStatic ? 2 : 3) : (targetMethod.IsStatic ? 1 : 2);
+                var callParams = instruction.Operands.Skip(callParamIndex);
                 foreach (var param in callParams)
                     LoadOperand(param, method, locals, writeLine, stringCtor);
 
@@ -414,7 +415,7 @@ public static class IlGenerator
                     break;
                 }
                 instructions.Add(CilOpCodes.Ldstr, "Unmanaged memory load: " + operand.ToString());
-                instructions.Add(CilOpCodes.Newobj, importer.ImportMethod(stringCtor));
+                instructions.Add(CilOpCodes.Call, importer.ImportMethod(writeLine));
                 break;
             case RuntimeMethodInfoAnalysisContext:
                 //Not fully implemented, these basically shouldn't actually ever exist in the final IL.

--- a/Cpp2IL.Core/InstructionSets/NewArmV8InstructionSet.cs
+++ b/Cpp2IL.Core/InstructionSets/NewArmV8InstructionSet.cs
@@ -250,7 +250,13 @@ public class NewArmV8InstructionSet : Cpp2IlInstructionSet
                 Add(address, OpCode.Move, dest2, mem2);
                 break;
             case Arm64Mnemonic.BL:
-                AddCall(context, GetReturnRegisterForContext(context), address, instruction.BranchTarget);
+                if (context.AppContext.MethodsByAddress.TryGetValue(instruction.BranchTarget, out var possibleMethods))
+                {
+                    if (possibleMethods.Count != 1)
+                        break;
+                   
+                    AddCall(context, GetReturnRegisterForContext(possibleMethods[0]), address, instruction.BranchTarget);
+                }
                 break;
             case Arm64Mnemonic.RET:
                 var returnRegister = GetReturnRegisterForContext(context);

--- a/Cpp2IL.Core/InstructionSets/NewArmV8InstructionSet.cs
+++ b/Cpp2IL.Core/InstructionSets/NewArmV8InstructionSet.cs
@@ -252,10 +252,16 @@ public class NewArmV8InstructionSet : Cpp2IlInstructionSet
             case Arm64Mnemonic.BL:
                 if (context.AppContext.MethodsByAddress.TryGetValue(instruction.BranchTarget, out var possibleMethods))
                 {
-                    if (possibleMethods.Count != 1)
-                        break;
-                   
-                    AddCall(context, GetReturnRegisterForContext(possibleMethods[0]), address, instruction.BranchTarget);
+                    if (possibleMethods.Count == 1)
+                        AddCall(context, GetReturnRegisterForContext(possibleMethods[0]), address, instruction.BranchTarget);
+                    else
+                        // TODO: Properly fix this case where branch address is potentially more than 1 method
+                        AddCall(context, GetReturnRegisterForContext(context), address, instruction.BranchTarget);
+                }
+                else
+                {
+                    // TODO: properly handle unmanaged/API function
+                    AddCall(context, GetReturnRegisterForContext(context), address, instruction.BranchTarget);
                 }
                 break;
             case Arm64Mnemonic.RET:


### PR DESCRIPTION
In #557 there was a bug added that was not previously found, for BL instructions we want to find the target function and use the return registers for the target function, so calls with void are not set for calls that are supposed to have a return type. 

Also logic for callParams did not take into account CallVoid OpCode.