### PR TITLE
IL Generation: Fix broken branching and omit methodinfo param load

### DIFF
--- a/Cpp2IL.Core/IlGenerator.cs
+++ b/Cpp2IL.Core/IlGenerator.cs
@@ -93,9 +93,47 @@ public static class IlGenerator
 
         // Generate IL
         Dictionary<Instruction, List<CilInstruction>> instructionMap = [];
-        foreach (var instruction in context.ControlFlowGraph!.Instructions) // context.ConvertedIsil is probably not up to date anymore here
-            instructionMap.Add(instruction, GenerateInstructions(instruction, context, definition, locals, writeLine, stringCtor));
+        Dictionary<Block, CilInstruction> blockEntryMap = [];
+        List<(CilInstruction BranchInstruction, Block TargetBlock)> pendingBlockBranchFixups = [];
 
+        foreach (var block in context.ControlFlowGraph!.Blocks)
+        {
+            if (block == context.ControlFlowGraph.EntryBlock || block == context.ControlFlowGraph.ExitBlock)
+                continue;
+
+            if (block.Instructions.Count == 0)
+                continue;
+
+            foreach (var instruction in block.Instructions)
+            {
+                var generated = GenerateInstructions(instruction, context, definition, locals, writeLine, stringCtor);
+                instructionMap.Add(instruction, generated);
+
+                if (!blockEntryMap.ContainsKey(block) && generated.Count > 0)
+                    blockEntryMap[block] = generated[0];
+            }
+
+            var lastInstruction = block.Instructions.Last();
+            
+            if (lastInstruction.OpCode == OpCode.ConditionalJump)
+            {
+                var trueTarget = TryResolveJumpTargetBlock(lastInstruction, context.ControlFlowGraph);
+                var falseSuccessor = block.Successors.FirstOrDefault(s => s != trueTarget && s != context.ControlFlowGraph.ExitBlock);
+                if (falseSuccessor == null) continue;
+                var bridge = new CilInstruction(CilOpCodes.Br, new CilInstructionLabel());
+                definition.CilMethodBody!.Instructions.Add(bridge);
+                pendingBlockBranchFixups.Add((bridge, falseSuccessor));
+            }
+
+            else if (lastInstruction.OpCode != OpCode.Jump && lastInstruction.OpCode != OpCode.Return && lastInstruction.OpCode != OpCode.IndirectJump)
+            {
+                var successor = block.Successors.FirstOrDefault(s => s != context.ControlFlowGraph.ExitBlock);
+                if (successor == null) continue;
+                var bridge = new CilInstruction(CilOpCodes.Br, new CilInstructionLabel());
+                definition.CilMethodBody!.Instructions.Add(bridge);
+                pendingBlockBranchFixups.Add((bridge, successor));
+            }
+        }
         // Set IL branch targets
         foreach (var kvp in instructionMap)
         {
@@ -127,6 +165,20 @@ public static class IlGenerator
                 ilBranch.Operand = new CilInstructionLabel(instructionMap[target][0]);
             }
         }
+        
+        foreach (var (branchInstruction, targetBlock) in pendingBlockBranchFixups)
+        {
+            var target = ResolveBlockEntryInstruction(targetBlock, blockEntryMap);
+            if (target == null)
+            {
+                context.AddWarning($"Unable to resolve branch target block: {targetBlock}");
+                branchInstruction.OpCode = CilOpCodes.Nop;
+                branchInstruction.Operand = null;
+                continue;
+            }
+
+            branchInstruction.Operand = new CilInstructionLabel(target);
+        }
 
         // Add analysis warnings
         var instructions = body.Instructions;
@@ -135,6 +187,39 @@ public static class IlGenerator
             instructions.Add(CilOpCodes.Ldstr, "Warning: " + warning);
             instructions.Add(CilOpCodes.Call, importer.ImportMethod(writeLine));
         }
+    }
+    
+    private static Block? TryResolveJumpTargetBlock(Instruction jumpInstruction, ISILControlFlowGraph cfg)
+    {
+        if (jumpInstruction.Operands.Count == 0)
+            return null;
+
+        if (jumpInstruction.Operands[0] is Block targetBlock)
+            return targetBlock;
+
+        if (jumpInstruction.Operands[0] is Instruction targetInstruction)
+            return cfg.FindBlockByInstruction(targetInstruction);
+
+        return null;
+    }
+
+    private static CilInstruction? ResolveBlockEntryInstruction(Block block,
+        Dictionary<Block, CilInstruction> blockEntryMap, HashSet<Block>? visited = null)
+    {
+        if (blockEntryMap.TryGetValue(block, out var target))
+            return target;
+
+        visited ??= [];
+        if (!visited.Add(block))
+            return null;
+
+        foreach (var successor in block.Successors)
+        {
+            var resolved = ResolveBlockEntryInstruction(successor, blockEntryMap, visited);
+            if (resolved != null)
+                return resolved;
+        }
+        return null;
     }
 
     private static List<CilInstruction> GenerateInstructions(Instruction instruction, MethodAnalysisContext context,
@@ -219,7 +304,9 @@ public static class IlGenerator
                 }
 
                 // Load normal params
-                var callParams = instruction.Operands.Skip(thisParamIndex + (targetMethod.IsStatic ? 0 : -1));
+                var callParams = instruction.Operands
+                    .Skip(thisParamIndex + (targetMethod.IsStatic ? 0 : -1))
+                    .Take(instruction.Operands.Count - 1 - thisParamIndex);
                 foreach (var param in callParams)
                     LoadOperand(param, method, locals, writeLine, stringCtor);
 


### PR DESCRIPTION
This resolves some issues with generated il.
Before:
```cs
private unsafe static void TestIfElse()
{
	//IL_0042: Expected I, but got O
	//IL_00ca: Expected I, but got O
	//IL_00dc: Expected O, but got I8
	//IL_018a: Expected O, but got I4
	//IL_0193: Expected I, but got O
	//IL_0253: Expected O, but got I4
	//IL_026d: Expected O, but got I4
	//IL_0287: Expected O, but got I4
	//IL_012c->IL012c: Incompatible stack heights: 5 vs 4
	//IL_015b->IL015b: Incompatible stack heights: 4 vs 5
	//IL_0169->IL017c: Incompatible stack heights: 5 vs 4
	if ((long)new string("Unmanaged memory load: [182206F3F]") == 0L)
	{
		Console.WriteLine("Unknown call target operand: 16 Call \"il2cpp_codegen_initialize_runtime_metadata\", v14 @ rax_v1, typeof(System.Console), v15 @ rdx, v16 @ r8, v17 @ r9");
		Console.WriteLine("Unknown call target operand: 18 Call \"il2cpp_codegen_initialize_runtime_metadata\", v37 @ rax_v2, typeof(System.DateTime), v15 @ rdx, v16 @ r8, v17 @ r9");
	}
	nint num = (nint)new DateTime();
	if ((long)new string("Unmanaged memory load: [v24 @ rcx_v9 (Il2CppClass<System.DateTime>)+E4]") == 0L)
	{
		Console.WriteLine("Unknown call target operand: 20 Call \"il2cpp_codegen_initialize_runtime_metadata\", v43 @ rax_v3, \"30 or above\", v15 @ rdx, v16 @ r8, v17 @ r9");
		Console.WriteLine("Unknown call target operand: 22 Call \"il2cpp_codegen_initialize_runtime_metadata\", v49 @ rax_v4, \"Under 30\", v15 @ rdx, v16 @ r8, v17 @ r9");
		Console.WriteLine("Unknown call target operand: 43 Call \"il2cpp_runtime_class_init_export\", v38 @ rax_v9, typeof(System.DateTime), v15 @ rdx, v16 @ r8, v17 @ r9");
	}
	_ = 0;
	DateTime now = DateTime.Now;
	int second = ((DateTime*)null)->Second;
	Console.WriteLine("Unknown call target operand: 24 Call \"il2cpp_codegen_initialize_runtime_metadata\", v61 @ rax_v5, \"Even second\", v15 @ rdx, v16 @ r8, v17 @ r9");
	Console.WriteLine("Unknown call target operand: 26 Call \"il2cpp_codegen_initialize_runtime_metadata\", v85 @ rax_v6, \"Odd second\", v15 @ rdx, v16 @ r8, v17 @ r9");
	nint num2 = (nint)new Console();
	object obj = second & 1L;
	if (obj != null)
	{
		Console.WriteLine("Unknown call target operand: 28 Call \"il2cpp_codegen_initialize_runtime_metadata\", v19 @ rax_v7, \"Single digit\", v15 @ rdx, v16 @ r8, v17 @ r9");
		_ = 1L;
		if ((long)new string("Unmanaged memory load: [v51 @ rcx_v12 (Il2CppClass<System.Console>)+E4]") != 0L)
		{
			goto IL_015b;
		}
	}
	if ((long)new string("Unmanaged memory load: [v51 @ rcx_v12 (Il2CppClass<System.Console>)+E4]") == 0L)
	{
		Console.WriteLine("Unknown call target operand: 73 Call \"il2cpp_runtime_class_init_export\", v86 @ rax_v13, typeof(System.Console), 0, v16 @ r8, v17 @ r9");
		goto IL_015b;
	}
	string text = "Even second";
	goto IL_017c;
	IL_015b:
	text = "Odd second";
	goto IL_017c;
	IL_017c:
	Console.WriteLine((string)0);
	nint num3 = (nint)new Console();
	if (second < 10L || second >= 30L)
	{
		if ((long)new string("Unmanaged memory load: [v106 @ rcx_v16 (Il2CppClass<System.Console>)+E4]") != 0L)
		{
			goto IL_0244;
		}
		if ((long)new string("Unmanaged memory load: [v106 @ rcx_v16 (Il2CppClass<System.Console>)+E4]") != 0L)
		{
			Console.WriteLine((string)0);
			return;
		}
	}
	if ((long)new string("Unmanaged memory load: [v106 @ rcx_v16 (Il2CppClass<System.Console>)+E4]") == 0L)
	{
		Console.WriteLine("Unknown call target operand: 171 Call \"il2cpp_runtime_class_init_export\", v164 @ rax_v23, typeof(System.Console), 0, v16 @ r8, v17 @ r9");
		goto IL_0244;
	}
	Console.WriteLine((string)0);
	return;
	IL_0244:
	Console.WriteLine((string)0);
}
```
After:
```cs
private unsafe static void TestIfElse()
{
	//IL_0277: Expected I, but got O
	//IL_00c4: Expected I, but got O
	//IL_00d6: Expected O, but got I8
	//IL_02b3: Expected I, but got O
	//IL_008d->IL026e: Incompatible stack heights: 1 vs 0
	if ((long)new string("Unmanaged memory load: [182206F3F]") == 0L)
	{
		Console.WriteLine("Unknown call target operand: 16 Call \"il2cpp_codegen_initialize_runtime_metadata\", v14 @ rax_v1, typeof(System.Console), v15 @ rdx, v16 @ r8, v17 @ r9");
		Console.WriteLine("Unknown call target operand: 18 Call \"il2cpp_codegen_initialize_runtime_metadata\", v37 @ rax_v2, typeof(System.DateTime), v15 @ rdx, v16 @ r8, v17 @ r9");
		Console.WriteLine("Unknown call target operand: 20 Call \"il2cpp_codegen_initialize_runtime_metadata\", v43 @ rax_v3, \"30 or above\", v15 @ rdx, v16 @ r8, v17 @ r9");
		Console.WriteLine("Unknown call target operand: 22 Call \"il2cpp_codegen_initialize_runtime_metadata\", v49 @ rax_v4, \"Under 30\", v15 @ rdx, v16 @ r8, v17 @ r9");
		Console.WriteLine("Unknown call target operand: 24 Call \"il2cpp_codegen_initialize_runtime_metadata\", v61 @ rax_v5, \"Even second\", v15 @ rdx, v16 @ r8, v17 @ r9");
		Console.WriteLine("Unknown call target operand: 26 Call \"il2cpp_codegen_initialize_runtime_metadata\", v85 @ rax_v6, \"Odd second\", v15 @ rdx, v16 @ r8, v17 @ r9");
		Console.WriteLine("Unknown call target operand: 28 Call \"il2cpp_codegen_initialize_runtime_metadata\", v19 @ rax_v7, \"Single digit\", v15 @ rdx, v16 @ r8, v17 @ r9");
		_ = 1L;
	}
	nint num = (nint)new DateTime();
	if ((long)new string("Unmanaged memory load: [v24 @ rcx_v9 (Il2CppClass<System.DateTime>)+E4]") == 0L)
	{
		Console.WriteLine("Unknown call target operand: 43 Call \"il2cpp_runtime_class_init_export\", v38 @ rax_v9, typeof(System.DateTime), v15 @ rdx, v16 @ r8, v17 @ r9");
	}
	DateTime now = DateTime.Now;
	int second = ((DateTime*)second)->Second;
	nint num2 = (nint)new Console();
	object obj = second & 1L;
	string value;
	if (obj != null)
	{
		if ((long)new string("Unmanaged memory load: [v51 @ rcx_v12 (Il2CppClass<System.Console>)+E4]") == 0L)
		{
			Console.WriteLine("Unknown call target operand: 73 Call \"il2cpp_runtime_class_init_export\", v86 @ rax_v13, typeof(System.Console), 0, v16 @ r8, v17 @ r9");
		}
		value = "Odd second";
	}
	else
	{
		if ((long)new string("Unmanaged memory load: [v51 @ rcx_v12 (Il2CppClass<System.Console>)+E4]") == 0L)
		{
			Console.WriteLine("Unknown call target operand: 88 Call \"il2cpp_runtime_class_init_export\", v89 @ rax_v15, typeof(System.Console), 0, v16 @ r8, v17 @ r9");
		}
		value = "Even second";
	}
	Console.WriteLine(value);
	nint num3 = (nint)new Console();
	if (second >= 10L)
	{
		if (second >= 30L)
		{
			if ((long)new string("Unmanaged memory load: [v106 @ rcx_v16 (Il2CppClass<System.Console>)+E4]") == 0L)
			{
				Console.WriteLine("Unknown call target operand: 131 Call \"il2cpp_runtime_class_init_export\", v168 @ rax_v19, typeof(System.Console), 0, v16 @ r8, v17 @ r9");
			}
			Console.WriteLine("30 or above");
		}
		else
		{
			if ((long)new string("Unmanaged memory load: [v106 @ rcx_v16 (Il2CppClass<System.Console>)+E4]") == 0L)
			{
				Console.WriteLine("Unknown call target operand: 151 Call \"il2cpp_runtime_class_init_export\", v172 @ rax_v21, typeof(System.Console), 0, v16 @ r8, v17 @ r9");
			}
			Console.WriteLine("Under 30");
		}
	}
	else
	{
		if ((long)new string("Unmanaged memory load: [v106 @ rcx_v16 (Il2CppClass<System.Console>)+E4]") == 0L)
		{
			Console.WriteLine("Unknown call target operand: 171 Call \"il2cpp_runtime_class_init_export\", v164 @ rax_v23, typeof(System.Console), 0, v16 @ r8, v17 @ r9");
		}
		Console.WriteLine("Single digit");
	}
}
```