### PR TITLE
Fix missing explicit interface implementations

### DIFF
--- a/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
@@ -545,11 +545,13 @@ public static class AsmResolverAssemblyPopulator
 
         foreach (var methodContext in typeContext.Methods)
         {
-            if ((methodContext.Attributes & System.Reflection.MethodAttributes.MemberAccessMask) != System.Reflection.MethodAttributes.Private)
-                continue;
+            var isPrivate = (methodContext.Attributes & System.Reflection.MethodAttributes.MemberAccessMask) == System.Reflection.MethodAttributes.Private;
 
             foreach (var overrideContext in methodContext.Overrides)
             {
+                if (overrideContext.Name == methodContext.Name && !isPrivate)
+                    continue;
+
                 var interfaceMethod = (IMethodDefOrRef)overrideContext.ToMethodDescriptor(importer.TargetModule);
                 var method = methodContext.GetExtraData<MethodDefinition>("AsmResolverMethod") ?? throw new($"AsmResolver method not found in method analysis context for {methodContext}");
                 type.MethodImplementations.Add(new MethodImplementation(interfaceMethod, method));


### PR DESCRIPTION
The logic around choosing whether or not to emit them was excluding public obfuscated methods.