### PR TITLE
Support overriding field offsets

### DIFF
--- a/Cpp2IL.Core/Model/Contexts/ConcreteGenericFieldAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/ConcreteGenericFieldAnalysisContext.cs
@@ -11,6 +11,8 @@ public class ConcreteGenericFieldAnalysisContext : FieldAnalysisContext
     public override FieldAttributes? OverrideAttributes { get => BaseFieldContext.OverrideAttributes; set => BaseFieldContext.OverrideAttributes = value; }
     public override object? DefaultConstantValue => BaseFieldContext.DefaultConstantValue;
     public override object? OverrideConstantValue { get => BaseFieldContext.OverrideConstantValue; set => BaseFieldContext.OverrideConstantValue = value; }
+    public override int DefaultOffset => BaseFieldContext.DefaultOffset;
+    public override int? OverrideOffset { get => BaseFieldContext.OverrideOffset; set => BaseFieldContext.OverrideOffset = value; }
     public override byte[] DefaultStaticArrayInitialValue => BaseFieldContext.DefaultStaticArrayInitialValue;
     public override byte[]? OverrideStaticArrayInitialValue { get => BaseFieldContext.OverrideStaticArrayInitialValue; set => BaseFieldContext.OverrideStaticArrayInitialValue = value; }
     public override TypeAnalysisContext DefaultFieldType { get; }

--- a/Cpp2IL.Core/Model/Contexts/FieldAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/FieldAnalysisContext.cs
@@ -53,7 +53,15 @@ public class FieldAnalysisContext : HasCustomAttributesAndName, IFieldInfoProvid
         set => OverrideConstantValue = value;
     }
 
-    public int Offset => BackingData == null ? 0 : AppContext.Binary.GetFieldOffsetFromIndex(DeclaringType.Definition!.TypeIndex, BackingData.IndexInParent, BackingData.Field.FieldIndex, DeclaringType.Definition.IsValueType, IsStatic);
+    public virtual int DefaultOffset => BackingData?.FieldOffset ?? -1;
+
+    public virtual int? OverrideOffset { get; set; }
+
+    public int Offset
+    {
+        get => OverrideOffset ?? DefaultOffset;
+        set => OverrideOffset = value;
+    }
 
     public virtual TypeAnalysisContext DefaultFieldType => DeclaringType.DeclaringAssembly.ResolveIl2CppType(RawFieldType)
                                                            ?? throw new($"Field type {RawFieldType} could not be resolved.");

--- a/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
+++ b/Cpp2IL.Core/Utils/AsmResolver/AsmResolverAssemblyPopulator.cs
@@ -346,8 +346,6 @@ public static class AsmResolverAssemblyPopulator
     {
         foreach (var fieldContext in typeContext.Fields)
         {
-            var fieldInfo = fieldContext.BackingData;
-
             var fieldTypeSig = fieldContext.ToTypeSignature(importer.TargetModule);
 
             var managedField = new FieldDefinition(fieldContext.Name, (FieldAttributes)fieldContext.Attributes, fieldTypeSig);
@@ -360,12 +358,9 @@ public static class AsmResolverAssemblyPopulator
             if (managedField.HasFieldRva)
                 managedField.FieldRva = new DataSegment(fieldContext.StaticArrayInitialValue);
 
-            if (fieldInfo != null)
-            {
-                if (ilTypeDefinition.IsExplicitLayout && !fieldContext.IsStatic)
-                    //Copy field offset
-                    managedField.FieldOffset = fieldInfo.FieldOffset;
-            }
+            //Copy field offset
+            if (ilTypeDefinition.IsExplicitLayout && !fieldContext.IsStatic)
+                managedField.FieldOffset = fieldContext.Offset;
 
             fieldContext.PutExtraData("AsmResolverField", managedField);
 


### PR DESCRIPTION
Note: the result for null `BackingData` has changed from 0 to -1, in order to align behavior with `Il2CppBinary::GetFieldOffsetFromIndex`.