### PR TITLE
Ensure BaseMethod is null for explicit interface implementations

### DIFF
--- a/Cpp2IL.Core.Tests/MethodOverridesTests.cs
+++ b/Cpp2IL.Core.Tests/MethodOverridesTests.cs
@@ -14,6 +14,8 @@ public class MethodOverridesTests
         var list = mscorlib.GetTypeByFullName("System.Collections.Generic.List`1")!;
         var iList = mscorlib.GetTypeByFullName("System.Collections.IList")!;
         var ordinalComparer = mscorlib.GetTypeByFullName("System.OrdinalComparer")!;
+        var resourceSet = mscorlib.GetTypeByFullName("System.Resources.ResourceSet")!;
+        var runtimeResourceSet = mscorlib.GetTypeByFullName("System.Resources.RuntimeResourceSet")!;
         using (Assert.EnterMultipleScope())
         {
             // Simple override
@@ -36,6 +38,12 @@ public class MethodOverridesTests
 
             // Interface methods should not override anything
             Assert.That(iList.Methods.Select(m => m.Overrides.Count), Is.All.EqualTo(0));
+
+            // System.Resources.RuntimeResourceSet inherits from System.Resources.ResourceSet.
+            // Both implement System.Collections.IEnumerable::GetEnumerator() explicitly.
+            Assert.That(resourceSet.Methods.Any(m => m.Name == "System.Collections.IEnumerable.GetEnumerator"));
+            Assert.That(runtimeResourceSet.BaseType, Is.EqualTo(resourceSet));
+            Assert.That(runtimeResourceSet.GetMethod("System.Collections.IEnumerable.GetEnumerator").BaseMethod, Is.Null);
         }
     }
 

--- a/Cpp2IL.Core/Model/Contexts/MethodAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/MethodAnalysisContext.cs
@@ -172,6 +172,11 @@ public class MethodAnalysisContext : HasGenericParameters, IMethodInfoProvider
                 if (vtableEntry is null or { Type: not MetadataUsageType.MethodDef } || vtableEntry.AsMethod() != Definition)
                     continue;
 
+                if (IsInterfaceSlot(this, i))
+                {
+                    continue;
+                }
+
                 var baseType = DeclaringType?.DefaultBaseType;
                 while (baseType is not null)
                 {
@@ -232,13 +237,46 @@ public class MethodAnalysisContext : HasGenericParameters, IMethodInfoProvider
                     if (i >= interfaceOffset.offset)
                     {
                         var interfaceTypeContext = interfaceOffset.Type.ToContext(CustomAttributeAssembly);
-                        if (interfaceTypeContext != null && TryGetMethodForSlot(interfaceTypeContext, i - interfaceOffset.offset, out var method))
+                        var slot = i - interfaceOffset.offset;
+                        if (interfaceTypeContext != null && TryGetMethodForSlot(interfaceTypeContext, slot, out var method) && !IsInterfaceSlot(method, slot))
                         {
                             yield return method;
                         }
                     }
                 }
             }
+        }
+    }
+
+    private static bool IsInterfaceSlot(MethodAnalysisContext method, int slot)
+    {
+        var declaringTypeDefinition = method.DeclaringType?.Definition;
+        if (declaringTypeDefinition == null)
+            return false;
+
+        foreach (var interfaceOffset in declaringTypeDefinition.InterfaceOffsets)
+        {
+            if (slot >= interfaceOffset.offset)
+            {
+                var interfaceTypeContext = interfaceOffset.Type.ToContext(method.CustomAttributeAssembly);
+                if (interfaceTypeContext != null && HasMethodForSlot(interfaceTypeContext, slot - interfaceOffset.offset))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static bool HasMethodForSlot(TypeAnalysisContext declaringType, int slot)
+    {
+        if (declaringType is GenericInstanceTypeAnalysisContext genericInstanceType)
+        {
+            return genericInstanceType.GenericType.Methods.Any(m => m.Slot == slot);
+        }
+        else
+        {
+            return declaringType.Methods.Any(m => m.Slot == slot);
         }
     }
 


### PR DESCRIPTION
When a base type and a derived type both implement the same interface, the derived type's BaseMethod currently returns the implementation of the derived type, but it should be null.