### PR TITLE
Fix NullReferenceException reading exported types on metadata v24.0

### DIFF
--- a/LibCpp2IL/Metadata/Il2CppMetadata.cs
+++ b/LibCpp2IL/Metadata/Il2CppMetadata.cs
@@ -373,7 +373,7 @@ public class Il2CppMetadata : ClassReadingBinaryReader
             stringLiterals = ReadMetadataClassArray<Il2CppStringLiteral>(metadataHeader.stringLiteral);
             LibLogger.VerboseNewline($"OK ({(DateTime.Now - start).TotalMilliseconds} ms)");
 
-            if (MetadataVersion > 24)
+            if (MetadataVersion >= 24)
             {
                 LibLogger.Verbose("\tReading exported types...");
                 start = DateTime.Now;


### PR DESCRIPTION
## Summary

`Il2CppImageDefinition.ExportedTypes` uses `IsAtLeast(24)` to decide whether to read exported types, but the code that populates the backing `Il2CppMetadata.exportedTypes` array (added in #554) uses `MetadataVersion > 24`, which excludes v24.0 itself.

The `exportedTypes` field is documented as "Added in v24" (see the field's own comment), so binaries whose resolved metadata version is exactly `24.0f` (Unity engine version < 2018.3 — see the version-resolution switch in `Il2CppMetadata.ReadFrom`) leave `exportedTypes` null, while `ExportedTypes` still indexes into it via `GetExportedTypeDefintionFromIndex`, throwing:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at LibCpp2IL.Metadata.Il2CppMetadata.GetExportedTypeDefintionFromIndex(Int32 index)
   at LibCpp2IL.Metadata.Il2CppImageDefinition.get_ExportedTypes()
   at Cpp2IL.Core.Utils.AsmResolver.AsmResolverAssemblyPopulator.ConfigureHierarchy(AssemblyAnalysisContext asmCtx)
```

This reproduces reliably with `--output-as dummydll` against any Unity < 2018.3, IL2CPP metadata v24 binary.

## Fix

One-line change: `MetadataVersion > 24` → `MetadataVersion >= 24`, consistent with `Il2CppImageDefinition.ExportedTypes`'s own `IsAtLeast(24)` check for the same field.

## Testing

Verified against a real-world Android IL2CPP binary (Unity 2017.4.17f1, metadata v24.0, ARM64): `--output-as dummydll` previously crashed as above; with this fix it completes successfully and produces the expected assembly count.

I looked at adding an automated regression test in `LibCpp2ILTests`, but none of the existing local (`TestFiles/`) or remote (`CheckFiles`) fixtures are actually Unity < 2018.3 — they're all 24.1+ sub-versions, which have different byte layouts and can't be forced to resolve as bare `24.0f` via the `UnityVersion` hint without desyncing the reader elsewhere (confirmed by trying). A fixture from an actual pre-2018.3 build would be needed for a clean automated test; happy to add one if you have a suitable sample to point at.