### PR TITLE
Fix NullReferenceException in GetTypeName for self-referencing generics

### DIFF
--- a/Cpp2IL.Core/Utils/CsFileUtils.cs
+++ b/Cpp2IL.Core/Utils/CsFileUtils.cs
@@ -277,8 +277,16 @@ public static class CsFileUtils
     /// This mainly involves stripping the backtick section from generic type names, and replacing certain system types with their primitive name.
     /// </summary>
     /// <param name="type"></param>
-    public static string GetTypeName(TypeAnalysisContext type)
+    public static string GetTypeName(TypeAnalysisContext? type)
     {
+        //GenericType/GenericArguments can observably be null here for a self-referencing generic type
+        //(e.g. `class Foo<T> : Bar<Foo<T>.Nested>`) - GenericInstanceTypeAnalysisContext caches itself in
+        //AssemblyAnalysisContext.GenericInstanceTypesByIl2CppType before its GenericType field is assigned,
+        //specifically to break resolution cycles (see https://github.com/SamboyCoding/Cpp2IL/issues/469),
+        //so a re-entrant resolution of the same type mid-construction can observe it as still-null.
+        if (type is null)
+            return "<unresolved type>";
+
         if (type is WrappedTypeAnalysisContext wrapped)
         {
             var elementTypeName = GetTypeName(wrapped.ElementType);


### PR DESCRIPTION
## Summary

`GenericInstanceTypeAnalysisContext` caches itself in `AssemblyAnalysisContext.GenericInstanceTypesByIl2CppType` before its `GenericType` property is assigned, specifically to break resolution cycles for self-referencing generic types (see #469 / #472):

```csharp
private GenericInstanceTypeAnalysisContext(Il2CppType rawType, AssemblyAnalysisContext referencedFrom) : base(referencedFrom)
{
    // Cache this instance before resolving anything else, which might contain a reference to this instance.
    referencedFrom.GenericInstanceTypesByIl2CppType.TryAdd(rawType, this);

    var gClass = rawType.GetGenericClass();
    GenericType = AppContext.ResolveContextForType(gClass.TypeDefinition) ?? throw new(...);
    ...
}
```

A re-entrant resolution of the same type mid-construction (i.e. while resolving `GenericType` for a self-referencing generic) can observe `GenericType` as still-null on the cached-but-not-yet-fully-constructed instance. `CsFileUtils.GetTypeName` dereferences its `type` argument unconditionally:

```
Processing layer attributeinjector threw an exception: System.AggregateException: One or more errors occurred. (Object reference not set to an instance of an object.)
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Cpp2IL.Core.Utils.CsFileUtils.GetTypeName(TypeAnalysisContext type) line 315
   at Cpp2IL.Core.Utils.CsFileUtils.GetTypeName(TypeAnalysisContext type) line 310
```

This aborts the whole `attributeinjector` processing layer (`--use-processor attributeinjector`) rather than just the one problematic attribute — everywhere else in this same code path (`HasCustomAttributes.AnalyzeCustomAttributeData` and friends) degrades gracefully with a `Supposedly had custom attributes (), but generator was null` warning instead of crashing, so this looked like the odd one out.

## Fix

Make `GetTypeName` tolerate a null `type` argument, returning a placeholder string instead of crashing, matching the existing degrade-gracefully convention used elsewhere in this file (e.g. the `"<unknown type?>"` fallback a few lines up in the same file).

## Testing

Verified against a real-world Android IL2CPP binary (Unity 2017.4.17f1, metadata v24.0, ARM64) that also triggers #568: `--use-processor attributeinjector` previously crashed as above; with this fix it completes ("Attribute Injector finished") and the output DLLs contain the expected `Cpp2ILInjected.Token`/`Address`/`FieldOffset` attributes. Also verified `attributeanalyzer`, `attributeinjector`, `callanalyzer`, and `nativemethoddetector` all run cleanly together against the same binary with this fix applied.