### PR TITLE
fix: Wine detection

### DIFF
--- a/Cpp2IL/ConsoleLogger.cs
+++ b/Cpp2IL/ConsoleLogger.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Drawing;
-using System.IO;
+#if Windows
+using System.Runtime.InteropServices;
+#endif
 using Cpp2IL.Core.Logging;
 using Pastel;
 
@@ -64,12 +66,18 @@ internal static class ConsoleLogger
         //     WarnNewline("Looks like you're running on a non-windows platform. Disabling ANSI color codes.");
         // }
         /*else*/
-        if (Directory.Exists(@"Z:\usr\"))
+
+#if Windows
+        // https://devblogs.microsoft.com/oldnewthing/20120514-00/?p=7633
+        // https://github.com/lain804/winedetect/blob/5f622df8cda9b26b4a1e8ded7171e281aae85a13/wine%20vibe%20check/main.cpp#L9-L11
+        if (Kernel32.MulDiv(1, int.MinValue, int.MinValue) != -1)
         {
             DisableColor = true;
             Logger.WarnNewline("Looks like you're running in wine or proton. Disabling ANSI color codes.");
         }
-        else if (Environment.GetEnvironmentVariable("NO_COLOR") != null)
+        else
+#endif
+        if (Environment.GetEnvironmentVariable("NO_COLOR") != null)
         {
             DisableColor = true; //Just manually set this, even though Pastel respects the environment variable
             Logger.WarnNewline("NO_COLOR set, disabling ANSI color codes as you requested.");
@@ -81,3 +89,11 @@ internal static class ConsoleLogger
         }
     }
 }
+
+#if Windows
+file class Kernel32
+{
+    [DllImport("kernel32.dll")]
+    public static extern int MulDiv(int nNumber, int nNumerator, int nDenominator);
+}
+#endif

--- a/Cpp2IL/Cpp2IL.csproj
+++ b/Cpp2IL/Cpp2IL.csproj
@@ -1,4 +1,4 @@
-﻿ <Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Company>Samboy063</Company>
         <Copyright>Copyright © Samboy063 2019-2026</Copyright>
@@ -9,22 +9,31 @@
         <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
         <OutputType>Exe</OutputType>
-        <PublishSingleFile Condition="'$(TargetFramework)'!='net472' and '$(GITHUB_ACTIONS)' == 'true'">true</PublishSingleFile>
+        <PublishSingleFile
+            Condition="'$(TargetFramework)'!='net472' and '$(GITHUB_ACTIONS)' == 'true'">true</PublishSingleFile>
         <TargetFrameworks>net10.0;net472</TargetFrameworks>
         <VersionPrefix>2022.1.0</VersionPrefix>
         <ServerGarbageCollection>true</ServerGarbageCollection>
         <CETCompat>false</CETCompat>
     </PropertyGroup>
 
-    <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+
+    <PropertyGroup
+        Condition="$(RuntimeIdentifier.StartsWith('win-')) Or ($(OS.Equals('Windows_NT')) And $(RuntimeIdentifier.Equals('')))">
+        <DefineConstants>Windows</DefineConstants>
+    </PropertyGroup>
+
+
+    <PropertyGroup
+        Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
         <TrimMode>partial</TrimMode>
         <PublishTrimmed>true</PublishTrimmed>
     </PropertyGroup>
-     
-     <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
-         <TrimmerRootAssembly Include="System.Runtime" />
-         <TrimmerRootAssembly Include="System.Private.CoreLib" />
-     </ItemGroup>
+
+    <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
+        <TrimmerRootAssembly Include="System.Runtime" />
+        <TrimmerRootAssembly Include="System.Private.CoreLib" />
+    </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
         <OutputPath>bin\x64\Debug\</OutputPath>
@@ -34,8 +43,8 @@
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="Pastel" Version="7.0.1" />
         <PackageReference Include="PolySharp" Version="1.15.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 


### PR DESCRIPTION
Checking if the `Z:/usr/` dir exists is very prone to false positives. In fact, I mount some volumes with this letter, and was falsely flagged as being on wine...