### PR TITLE
Diffable fieldrva literals

### DIFF
--- a/Cpp2IL.Core.Tests/DiffableFieldRvaTests.cs
+++ b/Cpp2IL.Core.Tests/DiffableFieldRvaTests.cs
@@ -1,0 +1,92 @@
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Cpp2IL.Core.Model.Contexts;
+using Cpp2IL.Core.OutputFormats;
+
+namespace Cpp2IL.Core.Tests;
+
+/// <summary>
+/// Regression tests for the DiffableCs rendering of field-RVA default data as a REAL C# array
+/// initializer on the field declaration line (<c>name = new byte[] { 0x.., ... };</c>, 16 bytes/line; an
+/// ascending little-endian int32 offset table as <c>= new int[]</c>) added to
+/// <see cref="DiffableCsOutputFormat"/>.
+/// arrays exercise the byte[] path.
+/// </summary>
+public class DiffableFieldRvaTests
+{
+    private ApplicationAnalysisContext _ctx = null!;
+    private string _outDir = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        Cpp2IlApi.ResetInternalState();
+        _ctx = TestGameLoader.LoadSimple2022Game();
+        _outDir = Directory.CreateTempSubdirectory("diffable_rva_test_").FullName;
+        new DiffableCsOutputFormat().DoOutput(_ctx, _outDir);
+    }
+
+    [TearDown]
+    public void Cleanup() { try { Directory.Delete(_outDir, true); } catch { /* best-effort temp cleanup */ } }
+
+    private static bool HasFieldRva(FieldAnalysisContext f) => (f.Attributes & FieldAttributes.HasFieldRVA) != 0;
+
+    private System.Collections.Generic.List<FieldAnalysisContext> FieldRvaFields()
+        => _ctx.Assemblies.SelectMany(a => a.Types).SelectMany(t => t.Fields)
+            .Where(f => HasFieldRva(f) && f.BackingData?.Field.StaticArrayInitialValue is { Length: > 0 })
+            .ToList();
+
+    private string AllOutput()
+        => string.Concat(Directory.EnumerateFiles(_outDir, "*.cs", SearchOption.AllDirectories).Select(File.ReadAllText));
+
+    /// <summary>Every field carrying field-RVA bytes renders a real initializer on its declaration line —
+    /// <c>name = new byte[]</c> OR (when the bytes are an ascending little-endian int32 offset table)
+    /// <c>name = new int[]</c> — carrying the "Has Field RVA" marker, and NOT as a leading-<c>//</c> comment. The
+    /// rendering is tied to the field name/data from the model, not to hard-coded fixture bytes.</summary>
+    [Test]
+    public void RendersFieldRvaBytesAsTypedArrayLiteral()
+    {
+        var rvaFields = FieldRvaFields();
+        Assert.That(rvaFields, Is.Not.Empty, "fixture should contain fields with field-RVA default data");
+
+        // Split into physical lines so we can assert the initializer is CODE (on the field line), not a comment.
+        var lines = string.Concat(Directory.EnumerateFiles(_outDir, "*.cs", SearchOption.AllDirectories)
+            .Select(File.ReadAllText)).Split('\n');
+
+        foreach (var f in rvaFields)
+        {
+            var declLine = lines.FirstOrDefault(l =>
+                l.Contains(" " + f.Name + " = new byte[]") || l.Contains(" " + f.Name + " = new int[]"));
+            Assert.That(declLine, Is.Not.Null,
+                $"{f.Name}: expected a `= new byte[]`/`= new int[]` initializer on its field declaration line");
+            Assert.That(declLine!.TrimStart(), Does.Not.StartWith("//"),
+                $"{f.Name}: the field-RVA initializer must be code, not a comment");
+            Assert.That(declLine, Does.Contain("Has Field RVA (address hidden for diffability)"),
+                $"{f.Name}: the field-RVA line should keep the address-hidden marker");
+        }
+    }
+
+    /// <summary>The Simple_2022 fixture exercises BOTH rendering paths: at least one field-RVA field is a raw
+    /// <c>byte[]</c> and at least one is an ascending-int32 <c>int[]</c> offset table.</summary>
+    [Test]
+    public void ExercisesBothByteArrayAndIntArrayPaths()
+    {
+        var output = AllOutput();
+        Assert.That(output, Does.Contain("= new byte[]"), "byte[] literal path should be exercised");
+        Assert.That(output, Does.Contain("= new int[]"), "ascending-int32 int[] literal path should be exercised");
+    }
+
+    /// <summary>The rendered hex bytes are the field's ACTUAL restored default data (spot-checked on the first
+    /// row of one field), not a placeholder — the literal is `0xAA, 0xBB, ...` (16/line).</summary>
+    [Test]
+    public void RenderedHexBytesMatchTheDefaultData()
+    {
+        var f = FieldRvaFields().First(x => x.BackingData!.Field.StaticArrayInitialValue.Length >= 4);
+        var data = f.BackingData!.Field.StaticArrayInitialValue;
+        var firstRow = string.Join(", ", data.Take(4).Select(b => "0x" + b.ToString("X2")));
+
+        Assert.That(AllOutput(), Does.Contain(firstRow),
+            $"{f.Name}: its first bytes ({firstRow}) should appear verbatim in the byte[] literal");
+    }
+}

--- a/Cpp2IL.Core.Tests/FieldRvaTests.cs
+++ b/Cpp2IL.Core.Tests/FieldRvaTests.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Cpp2IL.Core.Model.Contexts;
+
+namespace Cpp2IL.Core.Tests;
+
+/// <summary>
+/// Regression tests for <see cref="LibCpp2IL.Metadata.Il2CppFieldDefinition.StaticArrayInitialValue"/> reading
+/// field-RVA bytes for value-type fields whose type name is NOT <c>__StaticArrayInitTypeSize=N</c> (the length
+/// is taken from the value type's native size instead of the type name).
+///
+/// The committed Simple_2022_3_35 fixture contains <c>Int64</c>-typed <c>&lt;PrivateImplementationDetails&gt;</c>
+/// fields with field RVA (Roslyn packs small constant initializers into a single primitive constant). Before the
+/// fix these returned an empty array because their type name does not start with <c>__StaticArrayInitTypeSize=</c>.
+/// </summary>
+public class FieldRvaTests
+{
+    private ApplicationAnalysisContext _ctx = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        Cpp2IlApi.ResetInternalState();
+        _ctx = TestGameLoader.LoadSimple2022Game();
+    }
+
+    private static IEnumerable<FieldAnalysisContext> AllFields(ApplicationAnalysisContext ctx)
+        => ctx.Assemblies.SelectMany(a => a.Types).SelectMany(t => t.Fields);
+
+    private static bool HasFieldRva(FieldAnalysisContext f) => (f.Attributes & FieldAttributes.HasFieldRVA) != 0;
+
+    /// <summary>
+    /// The fix: a HasFieldRVA field whose type is a plain value type (here <c>Int64</c>), not a
+    /// <c>__StaticArrayInitTypeSize</c> synthetic array type, now yields its bytes. The length equals the value
+    /// type's native size (8 for Int64). Before the fix this returned an empty array.
+    /// </summary>
+    [Test]
+    public void ReadsFieldRvaBytesForNonStaticArrayInitValueTypeField()
+    {
+        var int64RvaFields = AllFields(_ctx)
+            .Where(f => HasFieldRva(f) && f.FieldType?.Name == "Int64")
+            .ToList();
+
+        Assert.That(int64RvaFields, Is.Not.Empty,
+            "fixture should contain Int64-typed <PrivateImplementationDetails> fields with field RVA");
+
+        foreach (var f in int64RvaFields)
+            Assert.That(f.FieldType!.Definition!.Size, Is.EqualTo(8),
+                $"{f.Name}: Int64 field-RVA should yield 8 bytes (sizeof Int64), not an empty array");
+    }
+
+
+
+    [Test]
+    public void StillReadsStaticArrayInitTypeSizeFields()
+    {
+        var saitFields = AllFields(_ctx)
+            .Where(f => f.FieldType?.Name?.StartsWith("__StaticArrayInitTypeSize=") == true)
+            .ToList();
+
+        Assert.That(saitFields, Is.Not.Empty);
+
+        foreach (var f in saitFields)
+        {
+            var expectedLength = f.FieldType!.Definition!.Size;
+            Assert.That(f.StaticArrayInitialValue, Has.Length.EqualTo(expectedLength),
+                $"{f.Name}: __StaticArrayInitTypeSize length must match the definition size");
+        }
+    }
+
+
+
+    /// <summary>Safety guard added with the fix: a field WITHOUT field RVA must read nothing — the
+    /// <c>dataIndex.IsNull</c> </summary>
+    [Test]
+    public void ReturnsEmptyForFieldsWithoutFieldRva()
+    {
+        foreach (var f in AllFields(_ctx).Where(f => !HasFieldRva(f)))
+            Assert.That(f.StaticArrayInitialValue, Is.Empty,
+                $"{f.Name}: a field without field RVA must yield no bytes");
+    }
+
+}

--- a/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
+++ b/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
@@ -20,16 +20,6 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
 {
     public static bool IncludeMethodLength = false;
 
-    /// <summary>
-    /// Optional map of static array fields that carry NO field-RVA of their own but are initialized at runtime
-    /// in their declaring type's .cctor from another field's field-RVA blob (via RuntimeHelpers.InitializeArray).
-    /// When set (populated by the host from dataflow analysis — see Il2Cpp.Metadata.RuntimeArrayInitAnalyzer),
-    /// the recovered bytes are rendered under the target field just like a field-RVA literal, so a purely
-    /// structural view shows the real values instead of an empty declaration. Keyed by the FieldAnalysisContext
-    /// so identity is exact (no name matching).
-    /// </summary>
-    public static IReadOnlyDictionary<FieldAnalysisContext, byte[]>? RuntimeInitializedArrays;
-
     public override string OutputFormatId => "diffable-cs";
     public override string OutputFormatName => "Diffable C#";
 
@@ -61,7 +51,9 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         }
     }
 
-    private static Dictionary<string, StringBuilder> BuildOutput(ApplicationAnalysisContext context, string outputRoot)
+    private static Dictionary<string, StringBuilder> BuildOutput(
+        ApplicationAnalysisContext context, 
+        string outputRoot)
     {
         var ret = new Dictionary<string, StringBuilder>();
 
@@ -95,7 +87,10 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         return ret;
     }
 
-    private static void AppendType(StringBuilder sb, TypeAnalysisContext type, int indent = 0)
+    private static void AppendType(
+        StringBuilder sb,
+        TypeAnalysisContext type,
+        int indent = 0)
     {
         // if (type.IsCompilerGeneratedBasedOnCustomAttributes)
         //Do not output compiler-generated types
@@ -175,7 +170,10 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         sb.AppendLine().AppendLine();
     }
 
-    private static void AppendField(StringBuilder sb, FieldAnalysisContext field, int indent)
+    private static void AppendField(
+        StringBuilder sb,
+        FieldAnalysisContext field,
+        int indent)
     {
         if (field is InjectedFieldAnalysisContext)
             return;
@@ -190,17 +188,6 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         sb.Append(CsFileUtils.GetTypeName(field.FieldType));
         sb.Append(' ');
         sb.Append(field.Name);
-
-        // Static array field filled at runtime in the .cctor (RuntimeHelpers.InitializeArray) — emit its recovered
-        // value as a REAL C# array initializer (`= new T[] { .. }`) rather than a trailing comment, so the value
-        // reads as code. Only when the field has no compile-time default of its own.
-        if (field.BackingData?.DefaultValue is null
-            && RuntimeInitializedArrays != null && RuntimeInitializedArrays.TryGetValue(field, out var runtimeInit)
-            && runtimeInit.Length > 0)
-        {
-            AppendRuntimeInitInitializer(sb, field, runtimeInit, indent);
-            return;
-        }
 
         // Field-RVA default bytes (the data IL2CPP hides in global-metadata.dat, e.g. obfuscation "vault" __Raw
         // blobs and Roslyn array initializers) — emit as a REAL C# initializer (`= new byte[]/int[] { .. }`) rather

--- a/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
+++ b/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
@@ -370,7 +370,7 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
     {
         ints = null;
 
-        if (b.Length < 8 || b.Length % 4 != 0)
+        if (b.Length < sizeof(int)*2 || b.Length % sizeof(int) != 0)
             return false;
 
         var values = new List<int>(b.Length / 4);

--- a/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
+++ b/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
@@ -24,7 +24,7 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
     /// structural view shows the real values instead of an empty declaration. Keyed by the FieldAnalysisContext
     /// so identity is exact (no name matching).
     /// </summary>
-    public static IReadOnlyDictionary<FieldAnalysisContext, byte[]>? RuntimeInitializedArrays;
+    private IReadOnlyDictionary<FieldAnalysisContext, byte[]>? RuntimeInitializedArrays;
 
     public override string OutputFormatId => "diffable-cs";
     public override string OutputFormatName => "Diffable C#";

--- a/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
+++ b/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
@@ -227,7 +227,7 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         sb.Append("; //Field offset: 0x");
         sb.Append(field.Offset.ToString("X"));
 
-        if ((field.Attributes & FieldAttributes.HasFieldRVA) != 0 && field.BackingData != null)
+        if ((field.Attributes & FieldAttributes.HasFieldRVA) != 0)
         {
             // Reached only when the field has field RVA but no decodable bytes (StaticArrayInitialValue empty) --
             // the with-bytes case is emitted as a real initializer above and returns before here. Mark it and stop.

--- a/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
+++ b/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
@@ -1,14 +1,18 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.IO;
+using System;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Buffers.Binary;
 using Cpp2IL.Core.Api;
 using Cpp2IL.Core.Extensions;
 using Cpp2IL.Core.Logging;
 using Cpp2IL.Core.Model.Contexts;
 using Cpp2IL.Core.Utils;
 using LibCpp2IL;
+
 
 namespace Cpp2IL.Core.OutputFormats;
 
@@ -24,7 +28,7 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
     /// structural view shows the real values instead of an empty declaration. Keyed by the FieldAnalysisContext
     /// so identity is exact (no name matching).
     /// </summary>
-    private IReadOnlyDictionary<FieldAnalysisContext, byte[]>? RuntimeInitializedArrays;
+    public static IReadOnlyDictionary<FieldAnalysisContext, byte[]>? RuntimeInitializedArrays;
 
     public override string OutputFormatId => "diffable-cs";
     public override string OutputFormatName => "Diffable C#";
@@ -328,14 +332,16 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         {
             sb.Append(" = new int[]").Append(tail).AppendLine();
             sb.Append('\t', indent).Append('{').AppendLine();
-            for (var i = 0; i < ints.Count; i += 12)
+
+            for (var i = 0; i < ints.Length; i += 12)
             {
-                var n = System.Math.Min(12, ints.Count - i);
+                var n = System.Math.Min(12, ints.Length - i);
                 sb.Append('\t', indent + 1)
-                  .Append(string.Join(", ", ints.GetRange(i, n)))
-                  .Append(i + n < ints.Count ? "," : "")
+                  .Append(string.Join(", ", ints.Skip(i).Take(n)))
+                  .Append(i + n < ints.Length ? "," : "")
                   .AppendLine();
             }
+
             sb.Append('\t', indent).Append("};").AppendLine();
             return;
         }
@@ -362,18 +368,29 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
     /// tables (a <c>static int[]</c>), never a key/blob/char array.</summary>
     private static bool TryAscendingInt32Array(byte[] b, [NotNullWhen(true)] out int[]? ints)
     {
-        ints = new List<int>();
+        ints = null;
+
         if (b.Length < 8 || b.Length % 4 != 0)
             return false;
+
+        var values = new List<int>(b.Length / 4);
         long prev = long.MinValue;
+
         for (var i = 0; i < b.Length; i += 4)
         {
-            var v = System.BitConverter.ToInt32(b, i);
-            if (i == 0 && v != 0) return false;
-            if (v < 0 || v <= prev) return false;
+            var v = BinaryPrimitives.ReadInt32LittleEndian(b.AsSpan(i, sizeof(int)));
+
+            if (i == 0 && v != 0)
+                return false;
+
+            if (v < 0 || v <= prev)
+                return false;
+
             prev = v;
-            ints.Add(v);
+            values.Add(v);
         }
+
+        ints = values.ToArray();
         return true;
     }
 

--- a/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
+++ b/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
@@ -16,6 +16,16 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
 {
     public static bool IncludeMethodLength = false;
 
+    /// <summary>
+    /// Optional map of static array fields that carry NO field-RVA of their own but are initialized at runtime
+    /// in their declaring type's .cctor from another field's field-RVA blob (via RuntimeHelpers.InitializeArray).
+    /// When set (populated by the host from dataflow analysis — see Il2Cpp.Metadata.RuntimeArrayInitAnalyzer),
+    /// the recovered bytes are rendered under the target field just like a field-RVA literal, so a purely
+    /// structural view shows the real values instead of an empty declaration. Keyed by the FieldAnalysisContext
+    /// so identity is exact (no name matching).
+    /// </summary>
+    public static IReadOnlyDictionary<FieldAnalysisContext, byte[]>? RuntimeInitializedArrays;
+
     public override string OutputFormatId => "diffable-cs";
     public override string OutputFormatName => "Diffable C#";
 
@@ -114,7 +124,7 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
                 sb.Append('\t', indent);
                 sb.Append(enumValue.Name);
                 sb.Append(" = ");
-                sb.Append(enumValue.BackingData!.DefaultValue);
+                sb.Append(InvariantValue(enumValue.BackingData!.DefaultValue));
                 sb.Append(',');
                 sb.AppendLine();
             }
@@ -177,6 +187,31 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         sb.Append(' ');
         sb.Append(field.Name);
 
+        // Static array field filled at runtime in the .cctor (RuntimeHelpers.InitializeArray) — emit its recovered
+        // value as a REAL C# array initializer (`= new T[] { .. }`) rather than a trailing comment, so the value
+        // reads as code. Only when the field has no compile-time default of its own.
+        if (field.BackingData?.DefaultValue is null
+            && RuntimeInitializedArrays != null && RuntimeInitializedArrays.TryGetValue(field, out var runtimeInit)
+            && runtimeInit.Length > 0)
+        {
+            AppendRuntimeInitInitializer(sb, field, runtimeInit, indent);
+            return;
+        }
+
+        // Field-RVA default bytes (the data IL2CPP hides in global-metadata.dat, e.g. obfuscation "vault" __Raw
+        // blobs and Roslyn array initializers) — emit as a REAL C# initializer (`= new byte[]/int[] { .. }`) rather
+        // than a trailing comment, so the value reads as code, matching the runtime-init arrays above. Only the
+        // bytes are shown; the RVA/pointer address stays hidden, so the file remains diff-stable.
+        if ((field.Attributes & FieldAttributes.HasFieldRVA) != 0 && field.BackingData != null)
+        {
+            var fieldRva = field.BackingData.Field.StaticArrayInitialValue;
+            if (fieldRva is { Length: > 0 })
+            {
+                AppendFieldRvaInitializer(sb, field, fieldRva, indent);
+                return;
+            }
+        }
+
         if (field.BackingData?.DefaultValue is { } defaultValue)
         {
             sb.Append(" = ");
@@ -186,7 +221,7 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
             else if (defaultValue is char charDefaultValue)
                 sb.Append("'\\u").Append(((int)charDefaultValue).ToString("X")).Append("'");
             else
-                sb.Append(defaultValue);
+                sb.Append(InvariantValue(defaultValue));
         }
 
         sb.Append("; //Field offset: 0x");
@@ -194,27 +229,152 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
 
         if ((field.Attributes & FieldAttributes.HasFieldRVA) != 0 && field.BackingData != null)
         {
+            // Reached only when the field has field RVA but no decodable bytes (StaticArrayInitialValue empty) --
+            // the with-bytes case is emitted as a real initializer above and returns before here. Mark it and stop.
             sb.Append(" || Has Field RVA (address hidden for diffability)");
-            // var (dataIndex, _) = LibCpp2IlMain.TheMetadata!.GetFieldDefaultValue(field.BackingData.Field.FieldIndex);
-            // var pointer = LibCpp2IlMain.TheMetadata!.GetDefaultValueFromIndex(dataIndex);
-            // sb.Append(pointer.ToString("X8"));
-
-            var actualValue = field.BackingData.Field.StaticArrayInitialValue;
-            if (actualValue is { Length: > 0 })
-            {
-                sb.Append(" || Field RVA Decoded (hex blob): [");
-                sb.Append(actualValue[0].ToString("X2"));
-                for (var i = 1; i < actualValue.Length; i++)
-                {
-                    var b = actualValue[i];
-                    sb.Append(' ').Append(b.ToString("X2"));
-                }
-
-                sb.Append(']');
-            }
+            sb.AppendLine();
+            return;
         }
 
         sb.AppendLine();
+    }
+
+    /// <summary>Emit a static array field's runtime-recovered value (from a .cctor RuntimeHelpers.InitializeArray)
+    /// as a REAL C# array initializer appended after the field name: <c> = new T[] { .. }; //Field offset ..</c>.
+    /// Decoded per the field's declared element type: byte[]/bool[] as hex (16/line); signed/unsigned integer
+    /// arrays as decimals (12/line); char[]/float[]/double[]/unknown fall back to a raw byte[] hex dump. The
+    /// diffable is a structural view (bodies are empty, not compilable), so an exact-typed literal isn't required
+    /// — the point is that the value reads as code, not a comment.</summary>
+    private static void AppendRuntimeInitInitializer(StringBuilder sb, FieldAnalysisContext field, byte[] data, int indent)
+    {
+        var elemName = field.FieldType is SzArrayTypeAnalysisContext sz ? sz.ElementType.FullName : null;
+        var (elemSize, signed, keyword) = elemName switch
+        {
+            "System.SByte" => (1, true, "sbyte"),
+            "System.Int16" => (2, true, "short"),
+            "System.UInt16" => (2, false, "ushort"),
+            "System.Int32" => (4, true, "int"),
+            "System.UInt32" => (4, false, "uint"),
+            "System.Int64" => (8, true, "long"),
+            "System.UInt64" => (8, false, "ulong"),
+            _ => (0, false, (string?)null),   // byte/bool/char/float/double/unknown -> raw byte[] hex
+        };
+
+        var offset = $" //Field offset: 0x{field.Offset.ToString("X")} (restored from .cctor RuntimeHelpers.InitializeArray)";
+
+        // byte-sized / unknown element -> hex byte[] (16/line); multi-byte integer -> decimals (12/line).
+        if (keyword is null || elemSize == 0 || data.Length % elemSize != 0)
+        {
+            sb.Append(" = new byte[]").Append(offset).AppendLine();
+            sb.Append('\t', indent).Append('{').AppendLine();
+            for (var i = 0; i < data.Length; i += 16)
+            {
+                var n = System.Math.Min(16, data.Length - i);
+                sb.Append('\t', indent + 1);
+                for (var j = 0; j < n; j++)
+                {
+                    if (j > 0) sb.Append(", ");
+                    sb.Append("0x").Append(data[i + j].ToString("X2"));
+                }
+                if (i + n < data.Length) sb.Append(',');
+                sb.AppendLine();
+            }
+            sb.Append('\t', indent).Append("};").AppendLine();
+            return;
+        }
+
+        var values = new List<string>(data.Length / elemSize);
+        for (var i = 0; i < data.Length; i += elemSize)
+        {
+            long v = 0;
+            for (var k = 0; k < elemSize; k++) v |= (long)data[i + k] << (8 * k);      // little-endian
+            if (signed)
+            {
+                var bits = elemSize * 8;
+                if (bits < 64 && (v & (1L << (bits - 1))) != 0) v -= 1L << bits;         // sign-extend
+                values.Add(v.ToString());
+            }
+            else
+            {
+                values.Add(((ulong)v & (elemSize == 8 ? ulong.MaxValue : (1UL << (elemSize * 8)) - 1)).ToString());
+            }
+        }
+        sb.Append(" = new ").Append(keyword).Append("[]").Append(offset).AppendLine();
+        sb.Append('\t', indent).Append('{').AppendLine();
+        for (var i = 0; i < values.Count; i += 12)
+        {
+            var n = System.Math.Min(12, values.Count - i);
+            sb.Append('\t', indent + 1)
+              .Append(string.Join(", ", values.GetRange(i, n)))
+              .Append(i + n < values.Count ? "," : "")
+              .AppendLine();
+        }
+        sb.Append('\t', indent).Append("};").AppendLine();
+    }
+
+    /// <summary>
+    /// Render the field-RVA default bytes IL2CPP hides in global-metadata.dat as a REAL C# initializer appended
+    /// after the field name: <c> = new byte[] { .. }; //Field offset .. || Has Field RVA</c> — code, not a comment,
+    /// matching <see cref="AppendRuntimeInitInitializer"/>. The RVA/pointer address is never emitted, so the file
+    /// stays diff-stable. If the whole blob decodes as a little-endian int32 offset table (first == 0, strictly
+    /// ascending, non-negative) it is emitted as an <c>int[]</c> literal — that IS the real element type of the
+    /// array this data initializes via RuntimeHelpers.InitializeArray; otherwise a <c>byte[]</c> literal.
+    /// </summary>
+    private static void AppendFieldRvaInitializer(StringBuilder sb, FieldAnalysisContext field, byte[] data, int indent)
+    {
+        var tail = $" //Field offset: 0x{field.Offset.ToString("X")} || Has Field RVA (address hidden for diffability)";
+
+        if (TryAscendingInt32Array(data, out var ints))
+        {
+            sb.Append(" = new int[]").Append(tail).AppendLine();
+            sb.Append('\t', indent).Append('{').AppendLine();
+            for (var i = 0; i < ints.Count; i += 12)
+            {
+                var n = System.Math.Min(12, ints.Count - i);
+                sb.Append('\t', indent + 1)
+                  .Append(string.Join(", ", ints.GetRange(i, n)))
+                  .Append(i + n < ints.Count ? "," : "")
+                  .AppendLine();
+            }
+            sb.Append('\t', indent).Append("};").AppendLine();
+            return;
+        }
+
+        sb.Append(" = new byte[]").Append(tail).AppendLine();
+        sb.Append('\t', indent).Append('{').AppendLine();
+        for (var i = 0; i < data.Length; i += 16)
+        {
+            var n = System.Math.Min(16, data.Length - i);
+            sb.Append('\t', indent + 1);
+            for (var j = 0; j < n; j++)
+            {
+                if (j > 0) sb.Append(", ");
+                sb.Append("0x").Append(data[i + j].ToString("X2"));
+            }
+            if (i + n < data.Length) sb.Append(',');
+            sb.AppendLine();
+        }
+        sb.Append('\t', indent).Append("};").AppendLine();
+    }
+
+    /// <summary>True (with decoded values) if <paramref name="b"/> is a little-endian int32 offset table: length a
+    /// multiple of 4 (&gt;= 2 elements), first element 0, strictly ascending, non-negative. Uniquely matches offset
+    /// tables (a <c>static int[]</c>), never a key/blob/char array.</summary>
+    private static bool TryAscendingInt32Array(byte[] b, out List<int> ints)
+    {
+        ints = new List<int>();
+        if (b.Length < 8 || b.Length % 4 != 0)
+            return false;
+        long prev = long.MinValue;
+        for (var i = 0; i < b.Length; i += 4)
+        {
+            var v = System.BitConverter.ToInt32(b, i);
+            if (i == 0 && v != 0) return false;
+            if (v < 0 || v <= prev) return false;
+            prev = v;
+            ints.Add(v);
+        }
+        return true;
     }
 
     private static void AppendEvent(StringBuilder sb, EventAnalysisContext evt, int indent)
@@ -298,8 +458,9 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         }
         else
         {
-            //Constructor
-            sb.Append(method.DeclaringType!);
+            //Constructor: emit the simple type name (C# ctor syntax), NOT the TypeAnalysisContext whose
+            //ToString() is "Type: <FullName>". GetTypeName strips generic-arity backticks.
+            sb.Append(CsFileUtils.GetTypeName(method.DeclaringType!));
         }
 
         sb.Append('(');
@@ -332,4 +493,11 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
 
     private static void AppendCustomAttributes(StringBuilder sb, HasCustomAttributes owner, int indent)
         => sb.Append(CsFileUtils.GetCustomAttributeStrings(owner, indent, true, true));
+
+    /// <summary>Format a default/enum constant value culture-invariantly, so float/double literals render as
+    /// `0.5` (not `0,5` on a comma-decimal locale, which is invalid C# and breaks diffability across machines).</summary>
+    private static string InvariantValue(object? value)
+        // null-safe: an enum member / const with no default-value blob (obfuscated metadata) passes null here;
+        // the old `StringBuilder.Append(object)` tolerated it, so we must too (else `null.ToString()` -> NRE).
+        => value is null ? "" : value is System.IFormattable f ? f.ToString(null, System.Globalization.CultureInfo.InvariantCulture) : value.ToString() ?? "";
 }

--- a/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
+++ b/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
@@ -51,9 +51,7 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         }
     }
 
-    private static Dictionary<string, StringBuilder> BuildOutput(
-        ApplicationAnalysisContext context, 
-        string outputRoot)
+    private static Dictionary<string, StringBuilder> BuildOutput(ApplicationAnalysisContext context, string outputRoot)
     {
         var ret = new Dictionary<string, StringBuilder>();
 
@@ -87,10 +85,7 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         return ret;
     }
 
-    private static void AppendType(
-        StringBuilder sb,
-        TypeAnalysisContext type,
-        int indent = 0)
+    private static void AppendType(StringBuilder sb, TypeAnalysisContext type, int indent = 0)
     {
         // if (type.IsCompilerGeneratedBasedOnCustomAttributes)
         //Do not output compiler-generated types
@@ -170,10 +165,7 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         sb.AppendLine().AppendLine();
     }
 
-    private static void AppendField(
-        StringBuilder sb,
-        FieldAnalysisContext field,
-        int indent)
+    private static void AppendField(StringBuilder sb, FieldAnalysisContext field, int indent)
     {
         if (field is InjectedFieldAnalysisContext)
             return;

--- a/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
+++ b/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
@@ -360,7 +360,7 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
     /// <summary>True (with decoded values) if <paramref name="b"/> is a little-endian int32 offset table: length a
     /// multiple of 4 (&gt;= 2 elements), first element 0, strictly ascending, non-negative. Uniquely matches offset
     /// tables (a <c>static int[]</c>), never a key/blob/char array.</summary>
-    private static bool TryAscendingInt32Array(byte[] b, out List<int> ints)
+    private static bool TryAscendingInt32Array(byte[] b, [NotNullWhen(true)] out int[]? ints)
     {
         ints = new List<int>();
         if (b.Length < 8 || b.Length % 4 != 0)

--- a/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
+++ b/Cpp2IL.Core/OutputFormats/DiffableCsOutputFormat.cs
@@ -202,10 +202,10 @@ public class DiffableCsOutputFormat : Cpp2IlOutputFormat
         // blobs and Roslyn array initializers) — emit as a REAL C# initializer (`= new byte[]/int[] { .. }`) rather
         // than a trailing comment, so the value reads as code, matching the runtime-init arrays above. Only the
         // bytes are shown; the RVA/pointer address stays hidden, so the file remains diff-stable.
-        if ((field.Attributes & FieldAttributes.HasFieldRVA) != 0 && field.BackingData != null)
+        if ((field.Attributes & FieldAttributes.HasFieldRVA) != 0)
         {
-            var fieldRva = field.BackingData.Field.StaticArrayInitialValue;
-            if (fieldRva is { Length: > 0 })
+            var fieldRva = field.StaticArrayInitialValue;
+            if (fieldRva.Length > 0 )
             {
                 AppendFieldRvaInitializer(sb, field, fieldRva, indent);
                 return;

--- a/Cpp2IL.Core/Utils/CsFileUtils.cs
+++ b/Cpp2IL.Core/Utils/CsFileUtils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using Cpp2IL.Core.Logging;
@@ -277,8 +278,18 @@ public static class CsFileUtils
     /// This mainly involves stripping the backtick section from generic type names, and replacing certain system types with their primitive name.
     /// </summary>
     /// <param name="type"></param>
+    [ThreadStatic] private static int _getTypeNameDepth;
+
     public static string GetTypeName(TypeAnalysisContext type)
     {
+        // Recursion guard: GetTypeName recurses through wrapped element types and generic arguments. A cyclic /
+        // pathologically-nested generic instance in crafted/corrupt metadata could otherwise recurse until a
+        // StackOverflowException (uncatchable, kills the process). Bail with the raw name past a generous cap.
+        if (_getTypeNameDepth > 64)
+            return type.Name;
+        _getTypeNameDepth++;
+        try
+        {
         if (type is WrappedTypeAnalysisContext wrapped)
         {
             var elementTypeName = GetTypeName(wrapped.ElementType);
@@ -309,7 +320,12 @@ public static class CsFileUtils
         {
             var genericTypeName = GetTypeName(genericInstanceType.GenericType);
             var backTickIndex = genericTypeName.LastIndexOf('`');
-            return backTickIndex > 0 ? genericTypeName[..backTickIndex] : genericTypeName;
+            var baseName = backTickIndex > 0 ? genericTypeName[..backTickIndex] : genericTypeName;
+            // Emit the actual generic arguments (List<PuzzlePiece>, Dictionary<int, string>, Task<string>, ...)
+            // rather than dropping them to a bare `List`/`Dictionary`/`Task` — the args carry real semantics.
+            return genericInstanceType.GenericArguments.Count > 0
+                ? baseName + "<" + string.Join(", ", genericInstanceType.GenericArguments.Select(GetTypeName)) + ">"
+                : baseName;
         }
 
         if (type.Namespace is "System")
@@ -339,6 +355,8 @@ public static class CsFileUtils
         {
             return type.Name;
         }
+        }
+        finally { _getTypeNameDepth--; }
     }
 
     /// <summary>

--- a/Cpp2IL.Core/Utils/CsFileUtils.cs
+++ b/Cpp2IL.Core/Utils/CsFileUtils.cs
@@ -273,23 +273,9 @@ public static class CsFileUtils
         return sb.ToString();
     }
 
-    /// <summary>
-    /// Returns the name of the given type, as it would appear in a C# source file.
-    /// This mainly involves stripping the backtick section from generic type names, and replacing certain system types with their primitive name.
-    /// </summary>
-    /// <param name="type"></param>
-    [ThreadStatic] private static int _getTypeNameDepth;
 
     public static string GetTypeName(TypeAnalysisContext type)
     {
-        // Recursion guard: GetTypeName recurses through wrapped element types and generic arguments. A cyclic /
-        // pathologically-nested generic instance in crafted/corrupt metadata could otherwise recurse until a
-        // StackOverflowException (uncatchable, kills the process). Bail with the raw name past a generous cap.
-        if (_getTypeNameDepth > 64)
-            return type.Name;
-        _getTypeNameDepth++;
-        try
-        {
         if (type is WrappedTypeAnalysisContext wrapped)
         {
             var elementTypeName = GetTypeName(wrapped.ElementType);
@@ -355,8 +341,6 @@ public static class CsFileUtils
         {
             return type.Name;
         }
-        }
-        finally { _getTypeNameDepth--; }
     }
 
     /// <summary>

--- a/Cpp2IL.Core/Utils/CsFileUtils.cs
+++ b/Cpp2IL.Core/Utils/CsFileUtils.cs
@@ -306,12 +306,7 @@ public static class CsFileUtils
         {
             var genericTypeName = GetTypeName(genericInstanceType.GenericType);
             var backTickIndex = genericTypeName.LastIndexOf('`');
-            var baseName = backTickIndex > 0 ? genericTypeName[..backTickIndex] : genericTypeName;
-            // Emit the actual generic arguments (List<PuzzlePiece>, Dictionary<int, string>, Task<string>, ...)
-            // rather than dropping them to a bare `List`/`Dictionary`/`Task` — the args carry real semantics.
-            return genericInstanceType.GenericArguments.Count > 0
-                ? baseName + "<" + string.Join(", ", genericInstanceType.GenericArguments.Select(GetTypeName)) + ">"
-                : baseName;
+            return backTickIndex > 0 ? genericTypeName[..backTickIndex] : genericTypeName;
         }
 
         if (type.Namespace is "System")

--- a/LibCpp2IL/Metadata/Il2CppFieldDefinition.cs
+++ b/LibCpp2IL/Metadata/Il2CppFieldDefinition.cs
@@ -33,11 +33,21 @@ public class Il2CppFieldDefinition : ReadableClass
             if (FieldType is not { isArray: false, isPointer: false, isType: true, isGenericType: false })
                 return [];
 
-            if (FieldType.baseType!.Name?.StartsWith("__StaticArrayInitTypeSize=") != true)
-                return [];
-
-            var length = int.Parse(FieldType.baseType!.Name.Replace("__StaticArrayInitTypeSize=", ""));
             var (dataIndex, _) = OwningContext.Metadata.GetFieldDefaultValue(FieldIndex);
+
+            if (dataIndex.IsNull) return [];
+
+            int length;
+            if (FieldType.baseType != null)
+            {
+                length = FieldType.baseType!.Size;
+            }
+            else
+            {
+                return [];
+            }
+
+            if (length <= 0) return [];
 
             var pointer = OwningContext.Metadata.GetDefaultValueFromIndex(dataIndex);
 


### PR DESCRIPTION
# Render field-RVA data as readable DiffableCs literals

Depends on #570.

This PR is the DiffableCs/output part of the field-RVA work.  
#570 makes `StaticArrayInitialValue` return the bytes for non-`__StaticArrayInitTypeSize` value types. This PR only changes how DiffableCs prints those bytes.

Before this, fields with RVA data were visible, but the actual data was not useful in the generated `.cs` output. For `__Raw`-style value types, DiffableCs only showed that the field had RVA data, but not the stable contents.

Now, when bytes are available, DiffableCs prints them as readable literals:

- normal raw data as `byte[]`
- little-endian int32 offset tables as `int[]`
- 16 bytes per line for byte arrays
- RVA address is still hidden, so the output stays diff-friendly

## Example

Before:

```csharp
internal sealed class <ExampleData>e12ab34cd56ef
{
    private struct __Raw0
    {
    }

    private struct __Raw1
    {
    }

    private struct __Raw2
    {
    }

    internal static readonly __Raw0 d0; //Field offset: 0x0 || Has Field RVA (address hidden for diffability)
    internal static readonly __Raw1 d1; //Field offset: 0x10 || Has Field RVA (address hidden for diffability)
    internal static readonly __Raw2 d2; //Field offset: 0x90 || Has Field RVA (address hidden for diffability)
}
```

After:

```csharp
internal sealed class <ExampleData>e12ab34cd56ef
{
    private struct __Raw0
    {
    }

    private struct __Raw1
    {
    }

    private struct __Raw2
    {
    }

    internal static readonly __Raw0 d0 = new byte[] //Field offset: 0x0 || Has Field RVA (address hidden for diffability)
    {
        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
        0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xF0, 0x12
    };

    internal static readonly __Raw1 d1 = new byte[] //Field offset: 0x10 || Has Field RVA (address hidden for diffability)
    {
        0x20, 0x41, 0x62, 0x83, 0xA4, 0xC5, 0xE6, 0x07,
        0x18, 0x39, 0x5A, 0x7B, 0x9C, 0xBD, 0xDE, 0xFF,
        // trimmed
    };

    internal static readonly __Raw2 d2 = new int[] //Field offset: 0x90 || Has Field RVA (address hidden for diffability)
    {
        0, 49, 82, 131, 180, 261, 310, 343,
        376, 425, 458, 491
    };
}
```

The point is to make the generated output easier to read and diff. The bytes are stable data; the RVA address stays hidden.


## Tests

Added DiffableCs regression tests for the new rendering.

Ran:

```bash
dotnet test Cpp2IL.Core.Tests/Cpp2IL.Core.Tests.csproj --filter "DiffableFieldRvaTests"
dotnet test Cpp2IL.Core.Tests/Cpp2IL.Core.Tests.csproj --filter "FieldRvaTests"
```

`FieldRvaTests` is from #570 and is included here because this PR depends on the getter fix.