### PR TITLE
GetTypeName: include generic type arguments

### DIFF
--- a/Cpp2IL.Core.Tests/GenericTypeArgsTests.cs
+++ b/Cpp2IL.Core.Tests/GenericTypeArgsTests.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using Cpp2IL.Core.Model.Contexts;
+using Cpp2IL.Core.Utils;
+
+namespace Cpp2IL.Core.Tests;
+
+
+public class GenericTypeArgsTests
+{
+    private ApplicationAnalysisContext _ctx = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        Cpp2IlApi.ResetInternalState();
+        _ctx = TestGameLoader.LoadSimple2022Game();
+    }
+
+    // Generic-instance types actually referenced in the fixture (field types — List<T>, Dictionary<K,V>, …).
+    private System.Collections.Generic.List<GenericInstanceTypeAnalysisContext> GenericInstances()
+        => _ctx.Assemblies.SelectMany(a => a.Types)
+            .SelectMany(t => t.Fields.Select(f => f.FieldType))
+            .OfType<GenericInstanceTypeAnalysisContext>()
+            .ToList();
+
+    [Test]
+    public void Fixture_has_generic_instances()
+    {
+        Assert.That(GenericInstances(), Is.Not.Empty);
+    }
+
+    [Test]
+    public void GetTypeName_appends_the_argument_list()
+    {
+        foreach (var gi in GenericInstances())
+        {
+            var name = CsFileUtils.GetTypeName(gi);
+
+            Assert.That(name, Does.Contain("<").And.Contain(">"), name);
+            Assert.That(name, Does.Not.Contain("`"),
+                $"CLR generic arity marker should not be rendered: {name}");
+
+            // the argument text is exactly each argument's own GetTypeName, comma-joined
+            var expectedArgs = string.Join(", ", gi.GenericArguments.Select(CsFileUtils.GetTypeName));
+            Assert.That(name, Does.EndWith("<" + expectedArgs + ">"), name);
+        }
+    }
+}

--- a/Cpp2IL.Core/Utils/CsFileUtils.cs
+++ b/Cpp2IL.Core/Utils/CsFileUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.CodeDom.Compiler;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using Cpp2IL.Core.Logging;
@@ -368,7 +369,10 @@ public static class CsFileUtils
         {
             var genericTypeName = GetTypeName(genericInstanceType.GenericType);
             var backTickIndex = genericTypeName.LastIndexOf('`');
-            return backTickIndex > 0 ? genericTypeName[..backTickIndex] : genericTypeName;
+            var baseName = backTickIndex > 0 ? genericTypeName[..backTickIndex] : genericTypeName;
+            return genericInstanceType.GenericArguments.Count > 0
+                ? baseName + "<" + string.Join(", ", genericInstanceType.GenericArguments.Select(GetTypeName)) + ">"
+                : baseName;
         }
 
         if (type.Namespace is "System")


### PR DESCRIPTION
# GetTypeName: include generic type arguments

`GetTypeName` currently removes the CLR arity suffix but also drops generic arguments.

```text
List`1 → List
Dictionary`2 → Dictionary
````

This change keeps the base name and appends the arguments recursively.

## Before / after

```csharp
// before
private List _entries;
private Dictionary _scores;

// after
private List<LeaderboardEntry> _entries;
private Dictionary<int, PlayerScore> _scores;
```

Nested generics also work:

```csharp
List<Dictionary<int, PlayerScore>>
```

## Test

`GenericTypeArgsTests` verifies that generic arguments are included, nested arguments use `GetTypeName`, and CLR markers such as `` `1 `` and `` `2 `` do not appear.
