### PR TITLE
Lib: Fix v106

### DIFF
--- a/LibCpp2IL/Metadata/Il2CppMetadata.cs
+++ b/LibCpp2IL/Metadata/Il2CppMetadata.cs
@@ -570,10 +570,10 @@ public class Il2CppMetadata : ClassReadingBinaryReader
             start = DateTime.Now;
             for (var i = 0; i < fieldDefaultValues.Length; i++)
             {
-                if(MetadataVersion >= 104 && i == fieldDefaultValues.Length - 1 && fieldDefaultValues[i].fieldIndex.Value == -1)
+                if(MetadataVersion >= 104 && i == fieldDefaultValues.Length - 1 && (fieldDefaultValues[i].fieldIndex.Value == -1 || fieldDefaultValues[i].fieldIndex.Value == int.MaxValue))
                     //v104 added this silly dummy entry at the end with field and type index -1. We skip it.
+                    //v106 changed it to int.MaxValue, which we will also test for and skip.
                     continue;
-                
                 var il2CppFieldDefaultValue = fieldDefaultValues[i];
                 _fieldDefaultValueLookup[il2CppFieldDefaultValue.fieldIndex] = il2CppFieldDefaultValue;
                 _fieldDefaultLookupNew[GetFieldDefinitionFromIndex(il2CppFieldDefaultValue.fieldIndex)] = il2CppFieldDefaultValue;


### PR DESCRIPTION
Add fieldIndex check to include int.MaxValue as v106 sometimes includes it instead of a value of -1

A little bit of context on this is I was modding a game called [Inside The Backrooms](https://store.steampowered.com/app/1987080/Inside_the_Backrooms/) that was recently added to [Thunderstore](https://thunderstore.io/c/inside-the-backrooms/) using MelonLoader and have run into this issue since the game was updated to use Unity 6.5 `(6000.5.0f1)`. After running through hoops to get things working, I traced the issue back to Cpp2IL and it was caused by this. Hope this PR helps to make the tool better.

P.S. still actively getting my updated build to work correctly in MelonLoader natively, I'll put more updates in here as I go.