### PR TITLE
Fix pre-v29 attributes

### DIFF
--- a/Cpp2IL.Core/Model/Contexts/HasCustomAttributes.cs
+++ b/Cpp2IL.Core/Model/Contexts/HasCustomAttributes.cs
@@ -188,6 +188,7 @@ public abstract class HasCustomAttributes(uint token, ApplicationAnalysisContext
         }
 
         CaCacheGeneratorAnalysis = new(generatorPtr, AppContext, this);
+        CaCacheGeneratorAnalysis.EnsureRawBytes();
         RawIl2CppCustomAttributeData = CaCacheGeneratorAnalysis.RawBytes;
     }
 
@@ -241,7 +242,7 @@ public abstract class HasCustomAttributes(uint token, ApplicationAnalysisContext
             var attributeTypeContext = AppContext.ResolveContextForType(typeDef) ?? throw new("Unable to find type " + typeDef.FullName);
 
             AnalyzedCustomAttribute attribute;
-            if (attributeTypeContext.Methods.FirstOrDefault(c => c.Name == ".ctor" && c.Definition!.parameterCount == 0) is { } constructor)
+            if (attributeTypeContext.Methods.FirstOrDefault(c => c.Name == ".ctor" && c.Parameters.Count == 0) is { } constructor)
             {
                 attribute = new(constructor);
             }

--- a/Cpp2IL.Core/Model/Contexts/MethodAnalysisContext.cs
+++ b/Cpp2IL.Core/Model/Contexts/MethodAnalysisContext.cs
@@ -328,13 +328,13 @@ public class MethodAnalysisContext : HasGenericParameters, IMethodInfoProvider, 
     {
         //Some abstract methods (on interfaces, no less) apparently have a body? Unity doesn't support default interface methods so idk what's going on here.
         //E.g. UnityEngine.Purchasing.AppleCore.dll: UnityEngine.Purchasing.INativeAppleStore::SetUnityPurchasingCallback on among us (itch.io build)
-        if (Definition != null && Definition.MethodPointer != 0 && !Definition.Attributes.HasFlag(MethodAttributes.Abstract))
+        if (UnderlyingPointer != 0 && !DefaultAttributes.HasFlag(MethodAttributes.Abstract))
         {
             RawBytes = AppContext.InstructionSet.GetRawBytesForMethod(this, this is AttributeGeneratorMethodAnalysisContext);
 
             if (RawBytes.Length == 0)
             {
-                Logger.VerboseNewline("\t\t\tUnexpectedly got 0-byte method body for " + this + $". Pointer was 0x{Definition.MethodPointer:X}", "MAC");
+                Logger.VerboseNewline("\t\t\tUnexpectedly got 0-byte method body for " + this + $". Pointer was 0x{UnderlyingPointer:X}", "MAC");
             }
         }
     }

--- a/Cpp2IL.Core/ProcessingLayers/AttributeAnalysisProcessingLayer.cs
+++ b/Cpp2IL.Core/ProcessingLayers/AttributeAnalysisProcessingLayer.cs
@@ -36,7 +36,7 @@ public class AttributeAnalysisProcessingLayer : Cpp2IlProcessingLayer
         }
     }
 
-    private void AnalyzeAndRaise(HasCustomAttributes toAnalyze, ref int count, int total, Action<int, int>? progressCallback)
+    private static void AnalyzeAndRaise(HasCustomAttributes toAnalyze, ref int count, int total, Action<int, int>? progressCallback)
     {
         toAnalyze.AnalyzeCustomAttributeData();
         count++;


### PR DESCRIPTION
This fixes a regression caused by https://github.com/SamboyCoding/Cpp2IL/commit/30256772f973e27c22a10b2c2d1c5606343c35c2.