### PR TITLE
x86: Lea instruction fixes

### DIFF
--- a/Cpp2IL.Core.Tests/Isil/X86IsilTests.cs
+++ b/Cpp2IL.Core.Tests/Isil/X86IsilTests.cs
@@ -1,5 +1,8 @@
 ﻿using Cpp2IL.Core.ISIL;
+using Cpp2IL.Core.InstructionSets;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 
 namespace Cpp2IL.Core.Tests.Isil;
 
@@ -77,6 +80,47 @@ public class X86IsilTests
                 instruction.SetOperand(0, instructions[(int)((Immediate)instruction.Operands[0]).Value]);
 
             Assert.True(instruction.IsStructurallyEqualTo(isil[i]), $"expected: {instruction}, but got {isil[i]}");
+        }
+    }
+    
+    [Test]
+    public void X86IsilLeaInstructionTests()
+    {
+        Register Register(string name) => new(null, name);
+
+        var testCases = new (string Bytes, ulong Ip, Instruction[] Expected)[]
+        {
+            ("8d 03", 0, [new(0, OpCode.Move, Register("rax"), Register("rbx"))]), // lea eax, [rbx]
+            ("8d 43 01", 0, [new(0, OpCode.Add, Register("rax"), Register("rbx"), Imm(1L))]), // lea eax, [rbx+0x1]
+            ("8d 4b ff", 0, [new(0, OpCode.Subtract, Register("rcx"), Register("rbx"), Imm(1L))]), // lea ecx, [rbx-0x1]
+            ("48 8d 0c 24", 0, [new(0, OpCode.Move, Register("rcx"), new AddressOf(new StackOffset(0)))]), // lea rcx, [rsp]
+            ("48 8d 4c 24 30", 0, [new(0, OpCode.Move, Register("rcx"), new AddressOf(new StackOffset(0x30)))]), // lea rcx, [rsp+0x30]
+            ("48 8d 4c 24 f0", 0, [new(0, OpCode.Move, Register("rcx"), new AddressOf(new StackOffset(-0x10)))]), // lea rcx, [rsp-0x10]
+            ("48 8d 04 0b", 0, [new(0, OpCode.Add, Register("rax"), Register("rbx"), Register("rcx"))]), // lea rax, [rbx+rcx]
+            ("48 8d 44 8b 10", 0, [new(0, OpCode.Multiply, Register("TEMP"), Register("rcx"), Imm(4)), 
+                                   new(1, OpCode.Add, Register("rax"), Register("rbx"), Register("TEMP")), 
+                                   new(2, OpCode.Add, Register("rax"), Register("rax"), Imm(0x10L))]), // lea rax, [rbx+rcx*4+0x10]
+            ("48 8d 04 8d 78 56 34 12", 0, [new(0, OpCode.Multiply, Register("rax"), Register("rcx"), Imm(4)), 
+                                            new(1, OpCode.Add, Register("rax"), Register("rax"), Imm(0x12345678L))]), // lea rax, [rcx*4+0x12345678]
+            ("48 8d 04 25 78 56 34 12", 0, [new(0, OpCode.Move, Register("rax"), Imm(0x12345678L))]), // lea rax, [0x12345678]
+            ("48 8d 83 00 00 00 80", 0, [new(0, OpCode.Subtract, Register("rax"), Register("rbx"), Imm(0x80000000L))]), // lea rax, [rbx-0x80000000]
+            ("48 8d 45 00", 0, [new(0, OpCode.Move, Register("rax"), Register("rbp"))]), // lea rax, [rbp]
+            ("48 8d 04 80", 0, [new(0, OpCode.Multiply, Register("TEMP"), Register("rax"), Imm(4)), 
+                                new(1, OpCode.Add, Register("rax"), Register("rax"), Register("TEMP"))]), // lea rax, [rax+rax*4]
+            ("48 8d 0d 10 4b d1 01", 0x1803A2C51UL, [new(0, OpCode.Move, Register("rcx"), Imm(0x1820B7768L))]), // lea rcx, [rel 0x1820b7768]
+        };
+        foreach (var (bytes, ip, expected) in testCases)
+        {
+            var instructionBytes = bytes.Split(' ').Select(byteValue => byte.Parse(byteValue, NumberStyles.HexNumber));
+            var decoder = Iced.Intel.Decoder.Create(64, new Iced.Intel.ByteArrayCodeReader(instructionBytes.ToArray()));
+            decoder.IP = ip;
+            decoder.Decode(out var x86Instruction);
+
+            var isil = new X86InstructionSet().GetIsilFromInstruction(x86Instruction);
+            
+            Assert.That(isil.Count, Is.EqualTo(expected.Length), x86Instruction.ToString);
+            for (var i = 0; i < expected.Length; i++)
+                Assert.That(isil[i].IsStructurallyEqualTo(expected[i]), Is.True, x86Instruction.ToString);
         }
     }
 }

--- a/Cpp2IL.Core/ISIL/AddressOf.cs
+++ b/Cpp2IL.Core/ISIL/AddressOf.cs
@@ -6,5 +6,9 @@ public class AddressOf(IOperand target) : IOperand
 {
     public IOperand Target = target;
 
+    public override bool Equals(object? obj) => obj is AddressOf other && Target.Equals(other.Target);
+
+    public override int GetHashCode() => Target.GetHashCode();
+
     public override string ToString() => $"&{Target}";
 }

--- a/Cpp2IL.Core/InstructionSets/X86InstructionSet.cs
+++ b/Cpp2IL.Core/InstructionSets/X86InstructionSet.cs
@@ -100,6 +100,13 @@ public class X86InstructionSet : Cpp2IlInstructionSet
         return X64CallingConventionResolver.ResolveForManaged(context).ToList();
     }
 
+    internal List<ISIL.Instruction> GetIsilFromInstruction(Instruction instruction)
+    {
+        var instructions = new List<ISIL.Instruction>();
+        ConvertInstructionStatement(instruction, instructions, [], null!);
+        return instructions;
+    }
+
     private void ConvertInstructionStatement(Instruction instruction, List<ISIL.Instruction> instructions, List<ulong> addresses, MethodAnalysisContext context)
     {
         var callNoReturn = false;
@@ -208,7 +215,82 @@ public class X86InstructionSet : Cpp2IlInstructionSet
                     break;
                 }
             case Mnemonic.Lea:
-                Add(instruction.IP, ISIL.OpCode.Move, ConvertOperand(instruction, 0), ConvertOperand(instruction, 1, true));
+                var destination = ConvertOperand(instruction, 0);
+
+                // RIP-relative LEA is effectively loading the absolute address.
+                if (instruction.IsIPRelativeMemoryOperand)
+                {
+                    Add(instruction.IP, ISIL.OpCode.Move, destination, Imm((long)instruction.IPRelativeMemoryAddress));
+                    return;
+                }
+
+                // Stack-address LEA keeps stack semantics represented as address-of stack slot.
+                if (instruction is { MemoryBase: Register.RSP, MemoryIndex: Register.None })
+                {
+                    Add(instruction.IP, ISIL.OpCode.Move, destination, ConvertOperand(instruction, 1, true));
+                    return;
+                }
+
+                // Absolute-address LEA also computes a value rather than loading from memory.
+                if (instruction.MemoryBase == Register.None && instruction.MemoryIndex == Register.None)
+                {
+                    Add(instruction.IP, ISIL.OpCode.Move, destination, Imm((long)instruction.MemoryDisplacement64));
+                    return;
+                }
+
+                if (instruction.MemoryIndex != Register.None)
+                {
+                    ISIL.IOperand? baseRegister = instruction.MemoryBase != Register.None
+                        ? new ISIL.Register(null, X86Utils.GetRegisterName(instruction.MemoryBase))
+                        : null;
+                    var indexRegister = new ISIL.Register(null, X86Utils.GetRegisterName(instruction.MemoryIndex));
+                    var source = (ISIL.IOperand)indexRegister;
+
+                    if (instruction.MemoryIndexScale > 1)
+                    {
+                        if (baseRegister != null)
+                        {
+                            var temp = new ISIL.Register(null, "TEMP");
+                            Add(instruction.IP, ISIL.OpCode.Multiply, temp, indexRegister, Imm(instruction.MemoryIndexScale));
+                            source = temp;
+                        }
+                        else
+                        {
+                            Add(instruction.IP, ISIL.OpCode.Multiply, destination, indexRegister, Imm(instruction.MemoryIndexScale));
+                            source = destination;
+                        }
+                    }
+
+                    if (baseRegister != null)
+                        Add(instruction.IP, ISIL.OpCode.Add, destination, baseRegister, source);
+                    else if (!ReferenceEquals(source, destination))
+                        Add(instruction.IP, ISIL.OpCode.Move, destination, source);
+
+                    var displacement = unchecked((long)instruction.MemoryDisplacement64);
+                    if (displacement > 0)
+                        Add(instruction.IP, ISIL.OpCode.Add, destination, destination, Imm(displacement));
+                    else if (displacement < 0)
+                        Add(instruction.IP, ISIL.OpCode.Subtract, destination, destination, Imm(-displacement));
+
+                    return;
+                }
+
+                if (instruction.MemoryBase != Register.None && instruction.MemoryBase != Register.RSP)
+                {
+                    var baseRegister = new ISIL.Register(null, X86Utils.GetRegisterName(instruction.MemoryBase));
+                    var displacement = unchecked((long)instruction.MemoryDisplacement64);
+
+                    if (displacement == 0)
+                        Add(instruction.IP, ISIL.OpCode.Move, destination, baseRegister);
+                    else if (displacement > 0)
+                        Add(instruction.IP, ISIL.OpCode.Add, destination, baseRegister, Imm(displacement));
+                    else
+                        Add(instruction.IP, ISIL.OpCode.Subtract, destination, baseRegister, Imm(-displacement));
+
+                    return;
+                }
+
+                Add(instruction.IP, ISIL.OpCode.Move, destination, ConvertOperand(instruction, 1, true));
                 break;
             case Mnemonic.Xor:
             case Mnemonic.Xorps: //xorps is just floating point xor


### PR DESCRIPTION
Attempt at fixing translation of lea instruction to isil in x86 instruction set.
Test cases to cover hopefully most possible scenarios have been added.

This fixes cases such as
```cs
private static int TestRecursion(int n)
{
	int result;
	if (n > 1)
	{
		Console.WriteLine("Unmanaged memory load: [n @ rcx (System.Int32)-1]");
		int num = TestRecursion(0);
		result = num * n;
		if (n == 5)
		{
			int result2 = default(int);
			string text = result2.ToString();
			string value = "Recursion result: " + text;
			Console.WriteLine(value);
			return result2;
		}
	}
	else
	{
		Console.WriteLine("Recursion base");
		result = 1;
	}
	return result;
}
```
to be like
```cs
private static int TestRecursion(int n)
{
	int result;
	if (n > 1)
	{
		int n2 = n - 1;
		int num = TestRecursion(n2);
		result = num * n;
		if (n == 5)
		{
			int result2 = default(int);
			string text = result2.ToString();
			string value = "Recursion result: " + text;
			Console.WriteLine(value);
			return result2;
		}
	}
	else
	{
		Console.WriteLine("Recursion base");
		result = 1;
	}
	return result;
}
```


