### PR TITLE
Raise metadata registration sanity limit for Unity 6 games

### DIFF
--- a/LibCpp2IL/BinarySearcher.cs
+++ b/LibCpp2IL/BinarySearcher.cs
@@ -349,10 +349,18 @@ public class BinarySearcher(Il2CppBinary binary, Il2CppMetadata metadata, int me
                     if (i % 2 == 0)
                     {
                         //Count
-                        ok = mrWords[i] < 0xC_0000;
+                        // Sanity limit for metadata registration count fields.
+                        // Unity 6 (6000.x) games can legitimately exceed 0xC0000
+                        // (e.g. Pax Autocratica on 2026-08 update had ~0xD04C4),
+                        // which made real registrations get rejected and interop
+                        // generation fail with "Failed to find code registration
+                        // or metadata registration!". Subsequent checks
+                        // (typeDefinitionsSizesCount / numTypes vs metadata)
+                        // still validate candidates, so this is only a coarse filter.
+                        ok = mrWords[i] < 0x4_00000;
 
                         if (!ok)
-                            LibLogger.VerboseNewline($"\t\t\tRejected Metadata registration at 0x{va:X}, because it has a count field 0x{mrWords[i]:X} at offset {i} which is above sanity limit of 0xC0000. If metadata registration detection fails, may need to bump up the limit.");
+                            LibLogger.VerboseNewline($"\t\t\tRejected Metadata registration at 0x{va:X}, because it has a count field 0x{mrWords[i]:X} at offset {i} which is above sanity limit of 0x400000. If metadata registration detection fails, may need to bump up the limit.");
                     }
                     else
                     {


### PR DESCRIPTION
## Problem

Unity 6 (6000.x) games can have metadata registration count fields above the hardcoded sanity limit of `0xC0000` (786,432). When that happens, real registrations get rejected and LibCpp2IL fails with:

`
LibCpp2ILInitializationException: Fatal Exception initializing LibCpp2IL!
 ---> System.Exception: Failed to find code registration or metadata registration!
`

**Repro:** Pax Autocratica after its 2026-08-15 update (Unity 6000.0.37f1). Cpp2IL verbose output:

`
Found 2 potential metadata registrations: [18E905CA0, 18E905CB0]
Rejected Metadata registration at 0x18E905CA0, because it has a count field 0xCFE2E at offset 0 which is above sanity limit of 0xC0000.
Rejected Metadata registration at 0x18E905CB0, because it has a count field 0xD04C4 at offset 8 which is above sanity limit of 0xC0000.
`

This breaks BepInEx interop generation for affected games (`Failed to generate Il2Cpp interop assemblies`).

## Fix

Raise the sanity limit to `0x400000` (4,194,304). Subsequent validation still applies: candidates are checked against the metadata file via `typeDefinitionsSizesCount` and `numTypes`, so this value only acts as a coarse pre-filter — it cannot accept a bogus registration.

This mirrors the 2022 precedent (commit history: limit was previously raised to `0x70000` for Zenith) and keeps the safety check while accommodating larger modern games.