### PR TITLE
Resolve field offsets through byref bases in ResolveFieldOffsets

### DIFF
--- a/Cpp2IL.Core/Analysis/MetadataResolver.cs
+++ b/Cpp2IL.Core/Analysis/MetadataResolver.cs
@@ -150,9 +150,15 @@ public static class MetadataResolver
                 if (memory.Base is not LocalVariable local || local?.Type == null)
                     continue;
 
+                // A byref-typed base (a managed pointer to a value type) has no fields of its
+                // own - IlGenerator's Ldfld emission accepts a managed pointer operand directly
+                // (same as it does for the addend==0 dereference case), so field resolution walks
+                // the referent's layout instead of the byref wrapper's, which is always empty.
+                var baseType = local.Type is ByRefTypeAnalysisContext { ElementType: { } referent } ? referent : local.Type;
+
                 // check if static field access
-                var staticOwner = (local.Type as StaticFieldStorageTypeAnalysisContext)?.OwnerType;
-                var owner = staticOwner ?? local.Type;
+                var staticOwner = (baseType as StaticFieldStorageTypeAnalysisContext)?.OwnerType;
+                var owner = staticOwner ?? baseType;
                 var genericOwner = owner as GenericInstanceTypeAnalysisContext;
 
                 FieldAnalysisContext? field;


### PR DESCRIPTION
`ResolveFieldOffsets` only succeeds when the memory operand's base local has a normal instance type with a populated `.Fields` list. When the base is a `ByRefTypeAnalysisContext` (a `T&` local — e.g. a `ref MyStruct data` parameter), `.Fields` is always empty, because the byref wrapper is a `ReferencedTypeAnalysisContext` with no `Definition`.

The offset therefore never resolves, and every field read through that `ref` parameter falls through to the `Unmanaged memory load` diagnostic — even though `Ldfld` accepts a managed pointer operand directly, which is the same precedent `IlGenerator`'s `addend == 0` byref dereference case already relies on.

This resolves field offsets against the referent (`.ElementType`) when the base is a byref, rather than against the byref wrapper itself.

### Measured

On a shipped Unity 6 IL2CPP title (x86-64, metadata v31), with only this diff toggled:

| | sites |
|---|---|
| `Unmanaged memory load` before | 20,807 |
| after | 20,336 |
| **eliminated** | **471** |

Verified rather than just gate-passed: one newly-resolved site (a byref base + `0x1C`) was checked against Il2CppInspector's dumped field layout for the same struct, which lists a field at `0x1C`. Exact match. A single heavy `ref` consumer in that title drops from 394 to 200 diagnostic sites.

The remainder of the 20,336 is a different problem (generic value-type layout and `Il2CppClass` runtime-metadata reads) and is deliberately left as diagnostics rather than guessed.