### PR TITLE
ARM64/ELF: Inline single-precision literal pool reads

### DIFF
--- a/Cpp2IL.Core/InstructionSets/NewArmV8InstructionSet.cs
+++ b/Cpp2IL.Core/InstructionSets/NewArmV8InstructionSet.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Disarm;
 using Cpp2IL.Core.Api;
@@ -187,6 +189,34 @@ public class NewArmV8InstructionSet : Cpp2IlInstructionSet
 
         adrpOffsets.Clear();
         return instructions;
+    }
+
+    /// <summary>
+    /// Reads the single-precision value held at a constant address, when that address is in a segment
+    /// the runtime cannot write. A writable segment only holds its final value once the runtime has
+    /// initialised it, so the bytes there are not a constant.
+    /// </summary>
+    private static bool TryReadSingleLiteral(MethodAnalysisContext context, long address,
+        [NotNullWhen(true)] out FloatLiteral? literal)
+    {
+        literal = null;
+
+        if (address <= 0)
+            return false;
+
+        var binary = context.AppContext.Binary;
+
+        if (!binary.IsVirtualAddressReadOnly((ulong)address)
+            || !binary.TryMapVirtualAddressToRaw((ulong)address, out var raw) || raw < 0)
+            return false;
+
+        var content = binary.GetRawBinaryContent();
+
+        if (raw + sizeof(float) > content.Length)
+            return false;
+
+        literal = new FloatLiteral(BinaryPrimitives.ReadSingleLittleEndian(content.Slice((int)raw, sizeof(float))));
+        return true;
     }
 
     private void ConvertInstructionStatement(Arm64Instruction instruction, List<Instruction> instructions, List<ulong> addresses, MethodAnalysisContext context)
@@ -471,6 +501,15 @@ public class NewArmV8InstructionSet : Cpp2IlInstructionSet
                     var source = instruction.Op1Kind == Arm64OperandKind.ImmediatePcRelative
                         ? new MemoryOperand(addend: (long)address + instruction.Op1Imm)
                         : MemOperand();
+
+                    // A single-precision load from a constant address in a segment the runtime cannot
+                    // write is a literal pool entry, so its value is known right here. Restricted to Sn
+                    // because the width is then unambiguous - an LDR Dn may hold two .2S lanes rather
+                    // than one double, and reading it as a double would invent a value.
+                    if (instruction.Op0Reg is >= Arm64Register.S0 and <= Arm64Register.S31
+                        && source is MemoryOperand { IsConstant: true } poolEntry
+                        && TryReadSingleLiteral(context, poolEntry.Addend, out var poolValue))
+                        source = poolValue;
 
                     if (instruction.Op0Kind == Arm64OperandKind.Register && IsReg31(instruction.Op0Reg))
                         Add(address, OpCode.Nop); // load to xzr = prefetch, discard

--- a/LibCpp2IL/Elf/ElfFile.cs
+++ b/LibCpp2IL/Elf/ElfFile.cs
@@ -526,6 +526,19 @@ public sealed class ElfFile : ElfStyleRelocationsBinary
 
     public override long RawLength => _raw.Length;
 
+    public override bool IsVirtualAddressReadOnly(ulong addr)
+    {
+        var segment = _elfProgramHeaderEntries.FirstOrDefault(x => x.Type == ElfProgramEntryType.PT_LOAD
+            && addr >= x.VirtualAddress
+            && addr < x.VirtualAddress + x.VirtualSize);
+
+        //Bytes past RawSize are zero-filled at load time (.bss) rather than read from the file, so only
+        //the file-backed part of a non-writable segment holds a constant.
+        return segment != null
+            && (segment.Flags & ElfProgramHeaderFlags.PF_W) == 0
+            && addr < segment.VirtualAddress + segment.RawSize;
+    }
+
     public override long MapVirtualAddressToRaw(ulong addr, bool throwOnError = true)
     {
         var section = _elfProgramHeaderEntries.FirstOrDefault(x => addr >= x.VirtualAddress && addr < x.VirtualAddress + x.VirtualSize);

--- a/LibCpp2IL/Il2CppBinary.cs
+++ b/LibCpp2IL/Il2CppBinary.cs
@@ -518,6 +518,13 @@ public abstract class Il2CppBinary(Stream input) : ClassReadingBinaryReader(inpu
     public abstract ulong GetVirtualAddressOfExportedFunctionByName(string toFind);
     public virtual bool IsExportedFunction(ulong addr) => false;
 
+    /// <summary>
+    /// Whether the bytes at the given virtual address cannot change once the binary is loaded, which
+    /// makes them a compile-time constant. Defaults to false, so a caller only gets a true answer from
+    /// a binary format that actually reports segment permissions.
+    /// </summary>
+    public virtual bool IsVirtualAddressReadOnly(ulong addr) => false;
+
     public virtual bool TryGetExportedFunctionName(ulong addr, [NotNullWhen(true)] out string? name)
     {
         name = null;


### PR DESCRIPTION
## Problem

On arm64 a float constant that does not fit an immediate is emitted into a literal pool and loaded via `adrp`/`ldr`:

```asm
adrp x8, <page>
ldr  s0, [x8, #<off>]
```

`NewArmV8InstructionSet` already folds that pair into an absolute address (the `adrpOffsets` path), so what reaches `IlGenerator` is a `MemoryOperand` with `IsConstant == true`. But the `MemoryOperand` case there only handles a byref dereference, so every literal pool read degrades to a diagnostic plus a zero:

```csharp
Cpp2ILHelpers.NoteDecompilerIssue("Unmanaged memory load: [1ED0730]");
... = 0;
```

The value is lost, and since the pushed zero often has the wrong stack type, ILSpy then reports type mismatches around it.

## Change

Three files, +59/-0.

- **`Il2CppBinary.IsVirtualAddressReadOnly(ulong)`** — new virtual predicate defaulting to `false`, the same conservative shape as the neighbouring `IsExportedFunction`. A format only answers true once it actually reports segment permissions.
- **`ElfFile`** overrides it: the address must lie in a `PT_LOAD` segment with `PF_W` clear, and below `RawSize` — bytes past that are zero-filled at load time rather than read from the file, so they are not constants.
- **`NewArmV8InstructionSet`**, in the LDR case: when the destination register is `S0`–`S31` and the source is a constant address in a read-only segment, the operand becomes a `FloatLiteral` instead of a `MemoryOperand`.

Producing the literal in the ISIL layer rather than at IL emission means `IlGenerator`'s existing `case FloatLiteral` handles it with no change, and the analysis passes get to see a constant as well.

### Why only `Sn`

An `LDR Dn` may be supplying two `.2S` lanes rather than one double, so reading 8 bytes there can fabricate a value out of two adjacent floats. `Sn` has an unambiguous width.

This is not hypothetical: an earlier revision of this patch took the width from the expected type instead of the destination register, and produced doubles such as `7.032822090631087E+19` — whose bit pattern is exactly `(57.2958f, 570f)`, i.e. `180/π` next to its neighbour in the pool.

## Effect

Two different Unity 2022.3 arm64 ELF binaries, `--output-as dll_il_recovery`:

| binary | literal pool reads inlined | methods recovered | `[Fail]` |
|---|---|---|---|
| A | 3,219 | 100% (135773 / 135776) | 0 |
| B | 3,206 | 100% (135096 / 135099) | 0 |

Recovery rate and failure count are unchanged, so the change is additive. Within one assembly of binary A, the decompiled output loses 463 `Unmanaged memory load` notes and 223 `Expected X, but got Y` remarks, and `Invalid comparison between …` drops from 150 to 64.

Spot checks on recovered values: a UI fade path that decompiled as `DOFade(0f, 0f)` now reads `DOFade(0f, 0.2f)`; recovered constants include `3.1415927410125732`, which is `(double)(float)π` and so confirms a 4-byte read rather than an 8-byte one, and `57.29578f`.

`Cpp2IL.Core.Tests` (76) and `LibCpp2ILTests` (5) pass unchanged.

## Not covered

- Only ELF implements the predicate. PE / Mach-O / NSO / WASM return `false` and are unaffected. The same ISIL shape exists on x86 — `X86InstructionSet` emits `MemoryOperand(addend: IPRelativeMemoryAddress)` for RIP-relative operands — so the predicate is reusable there, but I have no x86 sample to verify against and would rather not add an unexercised path.
- `LDR Dn` is deliberately left alone, for the width reason above.
- The repository's test samples are all Windows PE (`GameAssembly.dll`), so there is no arm64 ELF fixture to write a unit test against. Glad to add one if you would want such a sample included.
